### PR TITLE
Restored role dropdown functionality in custom blocks. Fixes #427

### DIFF
--- a/src/client/blocks.js
+++ b/src/client/blocks.js
@@ -896,7 +896,7 @@ InputSlotMorph.prototype.messageTypes = function () {
 };
 
 InputSlotMorph.prototype.roleNames = function () {
-    var ide = this.parentThatIsA(IDE_Morph),
+    var ide = this.root().children[0],
         roles = Object.keys(ide.room.roles),
         dict = {};
 


### PR DESCRIPTION
This issue occurs because the context of the InputSlotMorph is different when creating a custom block as seen [here](http://i.imgbox.com/JtxNfXkk.png). 

More specifically, when in the custom block creation window, there is no accessible NetsBloxMorph parent.

Additionally, this also fixes the related issue of the the target role being reset when the custom block is created.