### PR TITLE
Forced message hat block to process all SlotMorphs when updated. Fixes #449

### DIFF
--- a/src/client/message-listeners.js
+++ b/src/client/message-listeners.js
@@ -35,12 +35,14 @@ MessageOutputSlotMorph.prototype._updateFields = function(values) {
         i;
 
     // Remove the "i" fields after the current morph
-    // For MessageOutputMorph, I can simply remove the _msgContent
-    for (i = this._msgContent.length; i--;) {
-        input = this._msgContent[i];
-        removed.push(input);
-        this.parent.removeChild(input);
-    }
+    for (var i = 0; i < this.parent.children.length; i++) {
+         if (this.parent.children[i] instanceof ReadOnlyTemplateSlotMorph) {
+             input = this.parent.children[i];
+             removed.push(input);
+             this.parent.removeChild(input);
+             i--;
+         }
+      }
 
     if (scripts) {
         removed


### PR DESCRIPTION
With this change, the message hat block is forced to process _all_ SlotMorphs from the context of the parent when updated (specifically, `ReadOnlyTemplateSlotMorphs`, the morphs responsible for the field displays).

This fixes the duplication bug because, previously, `MessageOutputSlotMorphs` would modify the fields from its own context, which meant that in some circumstances like duplication, it wouldn't remove all of its fields.