### PR TITLE
Updated role destinations for room.

### DIFF
--- a/src/client/blocks.js
+++ b/src/client/blocks.js
@@ -906,7 +906,8 @@ InputSlotMorph.prototype.roleNames = function () {
         }
     }
 
-    dict['everyone'] = 'everyone';
+    dict['others in room'] = 'others in room';
+    dict['everyone in room'] = 'everyone in room';
     return dict;
 };
 

--- a/src/client/websockets.js
+++ b/src/client/websockets.js
@@ -34,7 +34,7 @@ WebSocketManager.MessageHandlers = {
             content = msg.content;
 
         // filter for gameplay
-        if (dstId === this.ide.projectName || dstId === 'everyone') {
+        if (dstId === this.ide.projectName || dstId === 'others in room' || dstId === 'everyone in room') {
             this.onMessageReceived(messageType, content, 'role');
         }
         // TODO: pass to debugger

--- a/src/server/rooms/ActiveRoom.js
+++ b/src/server/rooms/ActiveRoom.js
@@ -156,6 +156,11 @@ class ActiveRoom {
             .forEach(socket => socket.send(msg));
     }
 
+    // Send to everyone, including the origin socket
+    sendToRoom (socket, msg) {
+         this.sockets().forEach(socket => socket.send(msg));
+     }
+ 
     sockets () {
         return R.values(this.roles)
             .filter(socket => !!socket);

--- a/src/server/rooms/ActiveRoom.js
+++ b/src/server/rooms/ActiveRoom.js
@@ -157,7 +157,7 @@ class ActiveRoom {
     }
 
     // Send to everyone, including the origin socket
-    sendToRoom (socket, msg) {
+    sendToEveryone (socket, msg) {
          this.sockets().forEach(socket => socket.send(msg));
      }
  

--- a/src/server/rooms/NetsBloxSocket.js
+++ b/src/server/rooms/NetsBloxSocket.js
@@ -190,12 +190,12 @@ class NetsBloxSocket {
         assert.equal(this.roleId, role);
     }
 
-    sendToEveryone (msg) {
+    sendToOthers (msg) {
         this._room.sendFrom(this, msg);
     }
 
-    sendToRoom (msg) {
-        this._room.sendToRoom(this, msg);
+    sendToEveryone (msg) {
+        this._room.sendToEveryone(this, msg);
     }
 
     send (msg) {
@@ -232,7 +232,7 @@ NetsBloxSocket.MessageHandlers = {
     'beat': function() {},
 
     'message': function(msg) {
-        msg.dstId === 'others in room' ? this.sendToEveryone(msg) : this.sendToRoom(msg);
+        msg.dstId === 'others in room' ? this.sendToOthers(msg) : this.sendToEveryone(msg);
     },
 
     'project-response': function(msg) {

--- a/src/server/rooms/NetsBloxSocket.js
+++ b/src/server/rooms/NetsBloxSocket.js
@@ -194,6 +194,10 @@ class NetsBloxSocket {
         this._room.sendFrom(this, msg);
     }
 
+    sendToRoom (msg) {
+        this._room.sendToRoom(this, msg);
+    }
+
     send (msg) {
         msg = JSON.stringify(msg);
         this._logger.trace(`Sending message to ${this.uuid} "${msg}"`);
@@ -228,7 +232,7 @@ NetsBloxSocket.MessageHandlers = {
     'beat': function() {},
 
     'message': function(msg) {
-        this.sendToEveryone(msg);
+        msg.dstId === 'others in room' ? this.sendToEveryone(msg) : this.sendToRoom(msg);
     },
 
     'project-response': function(msg) {


### PR DESCRIPTION
This commit clarifies and updates the available role destinations for the room.

Instead of `everyone` signifying all the roles in the room _except_ for yourself, there are:

* `others in room`, taking the place of the old `everyone` and signifying all the roles in the room _except_ for yourself, and
* `everyone in room`, signifying _all_ the roles in the room, _including_ yourself

This provides convenience and functionality for the user because oftentimes there is a need for everyone in the room, including the current role, to react to a message that a role sends. Without this, the user would need to use the `broadcast` blocks, which would clutter up the screen and add unnecessary complexity to the project.