### PR TITLE
Added sharing of message types. Fixes #271

### DIFF
--- a/src/client/objects.js
+++ b/src/client/objects.js
@@ -958,6 +958,23 @@ SpriteMorph.prototype.deleteMessageType = function(name) {
 
     stage.messageTypes.deleteMsgType(name);
 
+
+    // Refresh message palette if possible in case the user is already on the 'Room' tab
+    try {
+        this.parentThatIsA(NetsBloxMorph).room.parentThatIsA(ProjectsMorph).updateRoom();
+        // We need to force-update & refresh to fix the layout after drawing the message palette
+        // We can do this by "clicking" the room tab
+        // FIXME: find a better way to refresh...
+        for (var i = 0; i < this.parentThatIsA(NetsBloxMorph).children.length; i++) {
+            if (this.parentThatIsA(NetsBloxMorph).children[i] instanceof Morph) {
+                if (this.parentThatIsA(NetsBloxMorph).children[i].tabBar) {  // found the tab morph
+                    this.parentThatIsA(NetsBloxMorph).children[i].tabBar.children[3].mouseClickLeft();  // simulate clicking the room tab
+                    return;
+                }
+            }
+        }
+    } catch(e) {}
+
     ide.flushBlocksCache(cat); // b/c of inheritance
     ide.refreshPalette();
 };
@@ -1008,6 +1025,22 @@ StageMorph.prototype.addMessageType = function (messageType) {
     fields = messageType.fields;
     msgType = new MessageType(name, fields);
     this.messageTypes.addMsgType(msgType);
+
+    // Refresh message palette if possible in case the user is already on the 'Room' tab
+    try {
+        this.parent.room.parentThatIsA(ProjectsMorph).updateRoom();
+        // We need to force-update & refresh to fix the layout after drawing the message palette
+        // We can do this by "clicking" the room tab
+        // FIXME: find a better way to refresh...
+        for (var i = 0; i < this.parent.children.length; i++) {
+            if (this.parent.children[i] instanceof Morph) {
+                if (this.parent.children[i].tabBar) {  // found the tab morph
+                    this.parent.children[i].tabBar.children[3].mouseClickLeft();  // simulate clicking the room tab
+                    return;
+                }
+            }
+        }
+    } catch(e) {}
 };
 
 StageMorph.prototype.processKeyEvent = function (event, action) {

--- a/src/client/objects.js
+++ b/src/client/objects.js
@@ -958,20 +958,11 @@ SpriteMorph.prototype.deleteMessageType = function(name) {
 
     stage.messageTypes.deleteMsgType(name);
 
-
     // Refresh message palette if possible in case the user is already on the 'Room' tab
     try {
-        this.parentThatIsA(NetsBloxMorph).room.parentThatIsA(ProjectsMorph).updateRoom();
-        // We need to force-update & refresh to fix the layout after drawing the message palette
-        // We can do this by "clicking" the room tab
-        // FIXME: find a better way to refresh...
-        for (var i = 0; i < this.parentThatIsA(NetsBloxMorph).children.length; i++) {
-            if (this.parentThatIsA(NetsBloxMorph).children[i] instanceof Morph) {
-                if (this.parentThatIsA(NetsBloxMorph).children[i].tabBar) {  // found the tab morph
-                    this.parentThatIsA(NetsBloxMorph).children[i].tabBar.children[3].mouseClickLeft();  // simulate clicking the room tab
-                    return;
-                }
-            }
+        ide.room.parentThatIsA(ProjectsMorph).updateRoom();
+        if (ide && ide.currentTab === 'room') {
+            ide.spriteBar.tabBar.tabTo('room');
         }
     } catch(e) {}
 
@@ -1028,17 +1019,10 @@ StageMorph.prototype.addMessageType = function (messageType) {
 
     // Refresh message palette if possible in case the user is already on the 'Room' tab
     try {
-        this.parent.room.parentThatIsA(ProjectsMorph).updateRoom();
-        // We need to force-update & refresh to fix the layout after drawing the message palette
-        // We can do this by "clicking" the room tab
-        // FIXME: find a better way to refresh...
-        for (var i = 0; i < this.parent.children.length; i++) {
-            if (this.parent.children[i] instanceof Morph) {
-                if (this.parent.children[i].tabBar) {  // found the tab morph
-                    this.parent.children[i].tabBar.children[3].mouseClickLeft();  // simulate clicking the room tab
-                    return;
-                }
-            }
+        var ide = this.parentThatIsA(NetsBloxMorph);
+        ide.room.parentThatIsA(ProjectsMorph).updateRoom();
+        if (ide && ide.currentTab === 'room') {
+            ide.spriteBar.tabBar.tabTo('room');
         }
     } catch(e) {}
 };

--- a/src/client/room.js
+++ b/src/client/room.js
@@ -415,7 +415,7 @@ RoomMorph.prototype.promptShare = function(name) {
                         name: name,
                         fields: myself.ide.stage.messageTypes.getMsgType(name).fields
                     });
-                    new DialogBoxMorph().inform('Sent', 'Successfully sent!', myself.world());
+                    myself.ide.showMessage('Successfully sent!', 2);
                 } else {  // not occupied, store in sharedMsgs array
                     myself.sharedMsgs.push({
                         roleId: choice, 
@@ -711,7 +711,7 @@ RoleMorph.prototype.reactToDropOf = function(drop) {
                 name: name,
                 fields: fields
             });
-            new DialogBoxMorph().inform('Sent', 'Successfully sent!', myself.world());
+            myself.parent.ide.showMessage('Successfully sent!', 2);
         } else {  // not occupied, store in sharedMsgs array
             myself.parent.sharedMsgs.push({
                 roleId: myself.name, 

--- a/src/client/room.js
+++ b/src/client/room.js
@@ -422,15 +422,15 @@ RoomMorph.prototype.promptShare = function(name) {
                         msg: {name: name, fields: myself.ide.stage.messageTypes.getMsgType(name).fields}, 
                         from: myself.ide.projectName
                         });
-                    new DialogBoxMorph().inform('Sent', 'The role will receive this message type on next occupation.', myself.world());
+                    myself.ide.showMessage('The role will receive this message type on next occupation.', 2);
                     }
             } else {
-                new DialogBoxMorph().inform('Unable to Send', 'There is no role by the name of \'' + choice + '\'!', myself.world());
+                myself.ide.showMessage('There is no role by the name of \'' + choice + '\'!', 2);
             }
             this.destroy();
         }
     } else {  // notify user no available recipients
-        new DialogBoxMorph().inform('No Available Recipients', 'There are no other roles in the room!', world);
+        myself.ide.showMessage('There are no other roles in the room!', 2);
     }
 };
 
@@ -700,7 +700,7 @@ RoleMorph.prototype.reactToDropOf = function(drop) {
     // Share the intended message type
     function shareMsgType(myself, name, fields) {
         if (myself.user && myself.parent.ide.projectName === myself.name) {  // occupied & myself
-            new DialogBoxMorph().inform('Failed to Send', 'Can\'t send a message type to yourself!', myself.world());
+            myself.parent.ide.showMessage('Can\'t send a message type to yourself!', 2);
             return;
         }
         if (myself.user && myself.parent.ide.projectName !== myself.name) {  // occupied & not myself
@@ -718,7 +718,7 @@ RoleMorph.prototype.reactToDropOf = function(drop) {
                 msg: {name: name, fields: fields}, 
                 from: myself.parent.ide.projectName
             });
-            new DialogBoxMorph().inform('Sent', 'The role will receive this message type on next occupation.', myself.world());
+            myself.parent.ide.showMessage('The role will receive this message type on next occupation.', 2);
         }
     }
     drop.destroy();

--- a/src/client/room.js
+++ b/src/client/room.js
@@ -424,6 +424,8 @@ RoomMorph.prototype.promptShare = function(name) {
                         });
                     new DialogBoxMorph().inform('Sent', 'The role will receive this message type on next occupation.', myself.world());
                     }
+            } else {
+                new DialogBoxMorph().inform('Unable to Send', 'There is no role by the name of \'' + choice + '\'!', myself.world());
             }
             this.destroy();
         }
@@ -903,7 +905,6 @@ ProjectsMorph.prototype.updateRoom = function() {
     this.addBack(this.contents);
 
     // Draw the room
-    // this.room.setExtent
     this.room.drawNew();
     this.addContents(this.room);
     this.drawMsgPalette();  // Draw the message palette
@@ -920,15 +921,14 @@ ProjectsMorph.prototype.updateRoom = function() {
 };
 
 ProjectsMorph.prototype.drawMsgPalette = function() {
-    var width = 110,
+    var width = 0,  // default width
         myself = this,
         stage = this.room.ide.stage;
 
     // Create and style the message palette
     var palette = new ScrollFrameMorph();
     palette.owner = this;
-    palette.scrollBarSize = width;
-    palette.setColor(new Color(40, 40, 40));
+    palette.setColor(new Color(71, 71, 71, 1));
     palette.setWidth(width);
     palette.setHeight(this.room.center().y * 2);
     palette.bounds = palette.bounds.insetBy(10);
@@ -969,8 +969,15 @@ ProjectsMorph.prototype.drawMsgPalette = function() {
         palette.addContents(msg);
     }
 
-    // Display message palette
+    // After adding all the sharable message types, resize the container if necessary
+    if (palette.contents.width() > palette.width()) {
+        palette.setWidth(palette.contents.width());
+        this.room.setPosition(new Point(palette.width() + 15, 0));  // Shift the room accordingly
+    }
+
+    // Display message palette with no scroll bar until it overflows
     this.addContents(palette);
+    this.vBar.hide();
 }
 
 ProjectsMorph.prototype.destroy = function() {

--- a/src/client/websockets.js
+++ b/src/client/websockets.js
@@ -140,17 +140,9 @@ WebSocketManager.MessageHandlers = {
                     acceptDialog.inform('Accepted', notification, myself.ide.root());
 
                     // refresh message palette
-                    myself.ide.room.parentThatIsA(ProjectsMorph).updateRoom();
-                    // We need to force-update & refresh to fix the layout after drawing the message palette
-                    // We can do this by "clicking" the room tab
-                    // FIXME: find a better way to refresh...
-                    for (var i = 0; i < myself.ide.children.length; i++) {
-                        if (myself.ide.children[i] instanceof Morph) {
-                            if (myself.ide.children[i].tabBar) {  // found the tab morph
-                                myself.ide.children[i].tabBar.children[3].mouseClickLeft();  // simulate clicking the room tab
-                                return;
-                            }
-                        }
+                    ide.room.parentThatIsA(ProjectsMorph).updateRoom();
+                    if (ide && ide.currentTab === 'room') {
+                        ide.spriteBar.tabBar.tabTo('room');
                     }
                 };
             }

--- a/src/client/websockets.js
+++ b/src/client/websockets.js
@@ -137,7 +137,7 @@ WebSocketManager.MessageHandlers = {
                     // notify
                     this.destroy();
                     var acceptDialog = new DialogBoxMorph();
-                    acceptDialog.inform('Accepted', notification, myself.ide.root());
+                    myself.ide.showMessage(notification, 2);
 
                     // refresh message palette
                     ide.room.parentThatIsA(ProjectsMorph).updateRoom();

--- a/src/client/websockets.js
+++ b/src/client/websockets.js
@@ -105,7 +105,7 @@ WebSocketManager.MessageHandlers = {
                 dialog = new DialogBoxMorph();
             // reject duplicates
             if (this.ide.stage.messageTypes.msgTypes[msg.name]) {
-                dialog.inform('Duplicate Message Type', msg.from + ' tried sending you message type \'' + msg.name + '\' when you already have it!', myself.ide.root());
+                this.ide.showMessage(msg.from + ' tried sending you message type \'' + msg.name + '\' when you already have it!', 2);
             } else {
                 // Prepare dialog & prompt user
                 var request = 

--- a/src/server/rooms/NetsBloxSocket.js
+++ b/src/server/rooms/NetsBloxSocket.js
@@ -373,7 +373,13 @@ NetsBloxSocket.MessageHandlers = {
                 });
             });
         }
-    }
+    },
+     
+     'share-msg-type': function(msg) {
+        // or simply this.sendToRoom()
+         this.send(msg);
+         this.sendToEveryone(msg);
+     }
 };
 
 module.exports = NetsBloxSocket;


### PR DESCRIPTION
This commit draws a message type palette to the left of the room for users to drag-and-drop message types to share among other roles in the room.

# Changes
* Displays a fixed message palette built with a scroll frame to the left of the room graphic
* Dynamic updates (whenever you make/delete/receive a message type, it refreshes)
  * NOTE: the current way of 'refreshing' the palette involves simulating a click of the 'room tab'. There should probably be a better way...however, without refreshing the palette, the focus on the room tab will be messed up on update of the palette (shifts to bottom right)
* **Drag and drop a message type from the palette to a role to share it**
* **Right click a message type from the palette to send it with a pop up dialog**
* **Left click a message type from the palette to view its fields**
* You are notified when...
  * you try and send a message type to yourself
  * successfully send a message type to another role
  * successfully queue up a message type to another role
  * receive a message type from another role
  * receive a message type that you already own from another role
* You can also drag and drop the `when I receive message` and `send message` blocks with their message field set to whatever message type you wish to send
