### PR TITLE
Room name changes on login if still default. Fixes #389

### DIFF
--- a/src/client/cloud.js
+++ b/src/client/cloud.js
@@ -339,6 +339,7 @@ NetCloud.prototype.passiveLogin = function (ide, callback) {
                     if (ide) {
                         ide.source = 'cloud';
                     }
+                    myself.onPassiveLogin();
                     callback();
                 }
             }

--- a/src/client/room.js
+++ b/src/client/room.js
@@ -51,8 +51,20 @@ function RoomMorph(ide) {
         }
     };
 
-    // update on login
-    SnapCloud.onLogin = this.update.bind(this);
+    // update on login (changing room name if default)
+    SnapCloud.onLogin = function() {
+        myself.update();
+        if (myself._name === localize('MyRoom')) {
+            myself.ide.sockets.sendMessage({type: 'request-new-name'});
+        }
+    }
+
+    // change room name if default on passive login
+    SnapCloud.onPassiveLogin = function() {
+        if (myself._name === localize('MyRoom')) {
+            myself.ide.sockets.sendMessage({type: 'request-new-name'});
+        }
+    }
 
     // Set the initial values
     var roles = {};

--- a/src/server/rooms/NetsBloxSocket.js
+++ b/src/server/rooms/NetsBloxSocket.js
@@ -373,6 +373,12 @@ NetsBloxSocket.MessageHandlers = {
                 });
             });
         }
+    },
+
+    'request-new-name': function() {
+        // get unique base name
+        this._room.name = false;
+        this._room.changeName();
     }
 };
 


### PR DESCRIPTION
This commit forces the room name to change on a user login if the room name is still the default name. 
As a result, users are now _unable_ to save a room as "MyRoom" when logged in (it will rename it before saving).