### PR TITLE
Fixed message creating artifacts upon resizing. Fixes #222

### DIFF
--- a/src/client/messages.js
+++ b/src/client/messages.js
@@ -97,6 +97,7 @@ MessageCreatorMorph.prototype.init = function(target, action) {
     this.addBody(messageBlock);
     var fixLayout = messageBlock.fixLayout;
     messageBlock.fixLayout = function() {
+        this.parent.drawNew();
         fixLayout.call(this);
         myself.fixLayout();
         myself.handle.drawNew();  // Should this be automatic?


### PR DESCRIPTION
This commit fixes the layout issues that occur when resizing the `MessageCreatorMorph` window.

As was suspected, the issue was due to the parent (`MessageCreatorMorph`) not being updated. 

The dialog window must be resized correctly before applying/updating any children layouts.