### PR TITLE
Added support for private project links. Fixes #937

### DIFF
--- a/src/client/netsblox.js
+++ b/src/client/netsblox.js
@@ -320,6 +320,38 @@ NetsBloxMorph.prototype.openIn = function (world) {
                     ]);
                 }, true);
             };
+        } else if (location.hash.substr(0, 9) === '#private:' || dict.action === 'private') {
+            var name = dict ? dict.ProjectName : location.hash.substr(9),
+                onConnect = this.sockets.onConnect,
+                msg;
+
+            this.sockets.onConnect = function() {
+                SnapCloud.passiveLogin(myself, function(isLoggedIn) {
+                    var msg;
+
+                    if (!isLoggedIn) {
+                        myself.showMessage('You are not logged in. Cannot open ' + name);
+                        return;
+                    }
+
+                    myself.nextSteps([
+                        function () {
+                            msg = this.showMessage('Opening ' + name + ' example...');
+                        },
+                        function () {nop(); }, // yield (bug in Chrome)
+                        function () {
+                            SnapCloud.callService(
+                                'getProject',
+                                function (response) {
+                                    myself.rawLoadCloudProject(response[0], dict.Public);
+                                },
+                                myself.cloudError(),
+                                [dict.ProjectName, SnapCloud.socketId()]
+                            );
+                        }
+                    ]);
+                }, true);
+            };
         // Netsblox addition: end
         }
     }

--- a/src/client/netsblox.js
+++ b/src/client/netsblox.js
@@ -321,14 +321,11 @@ NetsBloxMorph.prototype.openIn = function (world) {
                 }, true);
             };
         } else if (location.hash.substr(0, 9) === '#private:' || dict.action === 'private') {
-            var name = dict ? dict.ProjectName : location.hash.substr(9),
-                onConnect = this.sockets.onConnect,
-                msg;
+            var name = dict ? dict.ProjectName : location.hash.substr(9);
+            onConnect = this.sockets.onConnect;
 
             this.sockets.onConnect = function() {
                 SnapCloud.passiveLogin(myself, function(isLoggedIn) {
-                    var msg;
-
                     if (!isLoggedIn) {
                         myself.showMessage('You are not logged in. Cannot open ' + name);
                         return;
@@ -351,6 +348,7 @@ NetsBloxMorph.prototype.openIn = function (world) {
                         }
                     ]);
                 }, true);
+                myself.sockets.onConnect = onConnect;
             };
         // Netsblox addition: end
         }


### PR DESCRIPTION
This enables projects to be linked to using the syntax: `?action=private&ProjectName=SomeProjectName`. If the user is logged in (using a cookie) he/she will be able to open the project automatically.

These projects do not open in "app mode" as they are not published and it is assumed they are being worked on