### PR TITLE
return the error event and log better Fixes #1300

### DIFF
--- a/src/server/rpc/procedures/utils/api-consumer.js
+++ b/src/server/rpc/procedures/utils/api-consumer.js
@@ -74,7 +74,7 @@ class ApiConsumer {
             });
         }).catch(err => {
             this._logger.error('error in requesting data from', fullUrl, err);
-            return err;
+            throw err;
         });
     }
 
@@ -114,7 +114,7 @@ class ApiConsumer {
             });
             return deferred.promise.catch(err => {
                 this._logger.error('error in requesting the image',fullUrl, err);
-                return err;
+                throw err;
             });
         };
         if (queryOptions.cache === false) {

--- a/src/server/rpc/procedures/utils/api-consumer.js
+++ b/src/server/rpc/procedures/utils/api-consumer.js
@@ -74,6 +74,7 @@ class ApiConsumer {
             });
         }).catch(err => {
             this._logger.error('error in requesting data from', fullUrl, err);
+            return err;
         });
     }
 
@@ -112,7 +113,8 @@ class ApiConsumer {
                 deferred.reject(err);
             });
             return deferred.promise.catch(err => {
-                this._logger.error('error in requesting the image', err);
+                this._logger.error('error in requesting the image',fullUrl, err);
+                return err;
             });
         };
         if (queryOptions.cache === false) {


### PR DESCRIPTION
let the caller of apiConsumer methods get access to the event object in case of errors