### PR TITLE
update services to store their state under _state Fixes #1266

### DIFF
--- a/src/server/rpc/procedures/battleship/battleship.js
+++ b/src/server/rpc/procedures/battleship/battleship.js
@@ -16,6 +16,7 @@ var isHorizontal = dir => dir === 'east' || dir === 'west';
 class Battleship extends TurnBased {
     constructor () {
         super('fire', 'reset');
+        this._state = {};
         this._state._boards = {};
         this._state._STATE = BattleshipConstants.PLACING;
     }

--- a/src/server/rpc/procedures/battleship/board.js
+++ b/src/server/rpc/procedures/battleship/board.js
@@ -1,16 +1,16 @@
 // Board for playing battleship
 var SHIPS = require('./constants').SHIPS;
 var Board = function(size) {
-    this._ships = [];
-    this._shots = [];
+    this._state._ships = [];
+    this._state._shots = [];
     for (var i = size; i--;) {
-        this._shots.push(new Array(size));
-        this._ships.push(new Array(size));
+        this._state._shots.push(new Array(size));
+        this._state._ships.push(new Array(size));
     }
 
-    this._liveShips = {};
-    this._hits = {};
-    Object.keys(SHIPS).forEach(ship => this._hits[ship] = 0);
+    this._state._liveShips = {};
+    this._state._hits = {};
+    Object.keys(SHIPS).forEach(ship => this._state._hits[ship] = 0);
 };
 
 Board.prototype.placeShip = function(ship, row, col, erow, ecol) {
@@ -25,7 +25,7 @@ Board.prototype.placeShip = function(ship, row, col, erow, ecol) {
     // Check that the spots are open
     for (r = Math.max(row, erow); r >= minRow; r--) {
         for (c = maxCol; c >= minCol; c--) {
-            if (this._ships[r][c]) {
+            if (this._state._ships[r][c]) {
                 return false;
             }
         }
@@ -33,19 +33,19 @@ Board.prototype.placeShip = function(ship, row, col, erow, ecol) {
 
     for (r = Math.max(row, erow); r >= minRow; r--) {
         for (c = maxCol; c >= minCol; c--) {
-            this._ships[r][c] = ship;
+            this._state._ships[r][c] = ship;
         }
     }
 
-    this._liveShips[ship] = true;
+    this._state._liveShips[ship] = true;
     return true;
 };
 
 Board.prototype._remove = function(ship) {
-    for (var r = this._ships.length; r--;) {
-        for (var c = this._ships[r].length; c--;) {
-            if (this._ships[r][c] === ship) {
-                this._ships[r][c] = null;
+    for (var r = this._state._ships.length; r--;) {
+        for (var c = this._state._ships[r].length; c--;) {
+            if (this._state._ships[r][c] === ship) {
+                this._state._ships[r][c] = null;
             }
         }
     }
@@ -56,33 +56,33 @@ Board.prototype.fire = function(row, col) {
         ship;
 
     // Check if it is a reshoot?
-    if (this._shots[row][col]) {
+    if (this._state._shots[row][col]) {
         return null;
     }
 
     // Check if it hit a ship
-    if (ship = this._ships[row][col]) {
+    if (ship = this._state._ships[row][col]) {
         result.HIT = true;
         result.SHIP = ship;
-        this._hits[ship]++;
+        this._state._hits[ship]++;
 
         // Check if the ship sank
-        if (this._hits[ship] === SHIPS[ship]) {
+        if (this._state._hits[ship] === SHIPS[ship]) {
             result.SUNK = true;
-            this._liveShips[ship] = false;
+            this._state._liveShips[ship] = false;
         }
     }
 
-    this._shots[row][col] = true;
+    this._state._shots[row][col] = true;
     return result;
 };
 
 Board.prototype.remaining = function() {
-    return Object.keys(this._liveShips).filter(ship => this._liveShips[ship]);
+    return Object.keys(this._state._liveShips).filter(ship => this._state._liveShips[ship]);
 };
 
 Board.prototype.shipsLeftToPlace = function() {
-    return Object.keys(SHIPS).length - Object.keys(this._liveShips).length;
+    return Object.keys(SHIPS).length - Object.keys(this._state._liveShips).length;
 };
 
 module.exports = Board;

--- a/src/server/rpc/procedures/battleship/board.js
+++ b/src/server/rpc/procedures/battleship/board.js
@@ -1,6 +1,7 @@
 // Board for playing battleship
 var SHIPS = require('./constants').SHIPS;
 var Board = function(size) {
+    this._state = {};
     this._state._ships = [];
     this._state._shots = [];
     for (var i = size; i--;) {

--- a/src/server/rpc/procedures/connect-n/connect-n.js
+++ b/src/server/rpc/procedures/connect-n/connect-n.js
@@ -17,6 +17,7 @@ var debug = require('debug'),
  * @return {undefined}
  */
 var ConnectN = function() {
+    this._state = {};
     this._state.board = ConnectN.getNewBoard();
     this._state._winner = null;
     this._state.lastMove = null;

--- a/src/server/rpc/procedures/hangman/hangman.js
+++ b/src/server/rpc/procedures/hangman/hangman.js
@@ -6,9 +6,9 @@ var debug = require('debug'),
     info = debug('netsblox:rpc:hangman:info');
 
 var Hangman = function() {
-    this.word = null;
-    this.wrongGuesses = 0;
-    this.knownIndices = [];
+    this._state.word = null;
+    this._state.wrongGuesses = 0;
+    this._state.knownIndices = [];
 };
 
 Hangman.getPath = function() {
@@ -18,22 +18,22 @@ Hangman.getPath = function() {
 // Actions
 Hangman.prototype.setWord = function(word) {
     // TODO: Make sure the chooser is the only one calling this
-    this.word = word;
-    this.wrongGuesses = 0;
-    this.knownIndices = [];
-    info('Setting word to "'+this.word+'"');
+    this._state.word = word;
+    this._state.wrongGuesses = 0;
+    this._state.knownIndices = [];
+    info('Setting word to "'+this._state.word+'"');
 };
 
 Hangman.prototype.getCurrentlyKnownWord = function() {
-    var letters = this.word.split('').map(function() { 
-        return '_'; 
+    var letters = this._state.word.split('').map(function() {
+        return '_';
     });
 
-    this.knownIndices.forEach(function(index) {
-        letters[index] = this.word[index];
+    this._state.knownIndices.forEach(function(index) {
+        letters[index] = this._state.word[index];
     }, this);
     trace('Currently known word is "'+letters.join(' ')+'"');
-    trace('word is '+this.word);
+    trace('word is '+this._state.word);
     return letters.join(' ');
 };
 
@@ -47,22 +47,22 @@ Hangman.prototype.guess = function(letter) {
 
     letter = letter[0];
     trace('Guessing letter: '+letter);
-    indices = Hangman.getAllIndices(this.word, letter);
-    added = Hangman.merge(this.knownIndices, indices);
+    indices = Hangman.getAllIndices(this._state.word, letter);
+    added = Hangman.merge(this._state.knownIndices, indices);
     if (added === 0) {
-        this.wrongGuesses++;
+        this._state.wrongGuesses++;
     }
     return indices.map(index => index + 1);
 };
 
 Hangman.prototype.isWordGuessed = function() {
-    var isComplete = !!this.word && this.word.length === this.knownIndices.length;
+    var isComplete = !!this._state.word && this._state.word.length === this._state.knownIndices.length;
     return isComplete;
 };
 
 Hangman.prototype.getWrongCount = function() {
-    trace('wrong count is '+this.wrongGuesses);
-    return this.wrongGuesses;
+    trace('wrong count is '+this._state.wrongGuesses);
+    return this._state.wrongGuesses;
 };
 
 // Private

--- a/src/server/rpc/procedures/hangman/hangman.js
+++ b/src/server/rpc/procedures/hangman/hangman.js
@@ -6,6 +6,7 @@ var debug = require('debug'),
     info = debug('netsblox:rpc:hangman:info');
 
 var Hangman = function() {
+    this._state = {};
     this._state.word = null;
     this._state.wrongGuesses = 0;
     this._state.knownIndices = [];

--- a/src/server/rpc/procedures/n-player/n-player.js
+++ b/src/server/rpc/procedures/n-player/n-player.js
@@ -14,9 +14,9 @@ var R = require('ramda'),
  * @return {undefined}
  */
 var NPlayer = function() {
-    this.active = null;
-    this.previous = null;
-    this.players = [];
+    this._state.active = null;
+    this._state.previous = null;
+    this._state.players = [];
 };
 
 /**
@@ -32,19 +32,19 @@ NPlayer.getPath = function() {
 NPlayer.prototype.start = function() {
 
     // populate the players list
-    this.players = [];
-    
-    this.players = this.socket._room.sockets().map(socket => {
+    this._state.players = [];
+
+    this._state.players = this.socket._room.sockets().map(socket => {
         return {role: socket.roleId, socket: socket};
     });
 
     // set the active player to the current one
-    this.active = R.findIndex(R.propEq('role', this.socket.roleId))(this.players);
+    this._state.active = R.findIndex(R.propEq('role', this.socket.roleId))(this._state.players);
 
-    info(`Player #${this.active} (${this.players[this.active].role}) is (re)starting a ${this.players.length} player game`);
+    info(`Player #${this._state.active} (${this._state.players[this._state.active].role}) is (re)starting a ${this._state.players.length} player game`);
 
     // Send the start message to everyone
-    this.players.forEach(player => player.socket.send({
+    this._state.players.forEach(player => player.socket.send({
         type: 'message',
         dstId: player.role,
         msgType: 'start game',
@@ -55,35 +55,35 @@ NPlayer.prototype.start = function() {
 };
 
 // get the number of players
-NPlayer.prototype.getN = function() {    
-    return this.players.length;
+NPlayer.prototype.getN = function() {
+    return this._state.players.length;
 };
 
 // get the active role
 NPlayer.prototype.getActive = function() {
-    if(this.players.length === 0) {
+    if(this._state.players.length === 0) {
         return '';
     } else {
-        return this.players[this.active].role;
+        return this._state.players[this._state.active].role;
     }
 };
 
 // get the previous role
 NPlayer.prototype.getPrevious = function() {
-    if(this.previous == null || this.players.length == 0) {
+    if(this._state.previous == null || this._state.players.length == 0) {
         return '';
     } else {
-        return this.players[this.previous].role;
+        return this._state.players[this._state.previous].role;
     }
 };
 
 // get the next role
 NPlayer.prototype.getNext = function() {
-    if(this.players.length == 0) {
+    if(this._state.players.length == 0) {
         return '';
     } else {
-        var index = (this.active + 1) % this.players.length;
-        return this.players[index].role;
+        var index = (this._state.active + 1) % this._state.players.length;
+        return this._state.players[index].role;
     }
 };
 
@@ -91,34 +91,34 @@ NPlayer.prototype.getNext = function() {
 // signal end of turn
 NPlayer.prototype.endTurn = function(next) {
 
-    if(this.active === null || this.socket.roleId != this.players[this.active].role ) {
+    if(this._state.active === null || this.socket.roleId != this._state.players[this._state.active].role ) {
         // bail out if there's no game yet, or if it's somebody else's turn
         return false;
     } else {
 
-        info(`Player #${this.active} (${this.players[this.active].role}) called endTurn`);
+        info(`Player #${this._state.active} (${this._state.players[this._state.active].role}) called endTurn`);
 
         var nextIndex;
         if(next == undefined || next == '') {
-            nextIndex = (this.active + 1) % this.players.length;
+            nextIndex = (this._state.active + 1) % this._state.players.length;
         } else {
-            nextIndex = R.findIndex(R.propEq('role', next), this.players);
+            nextIndex = R.findIndex(R.propEq('role', next), this._state.players);
             if(nextIndex === -1) {
                 info('Role ' +next+ ' is not part of the game');
                 return false;
-            }                       
+            }
         }
 
         // save previous player's index, and make the next player active
-        this.previous = this.active;
-        this.active = nextIndex;
+        this._state.previous = this._state.active;
+        this._state.active = nextIndex;
 
-        info('Player #' +this.active+' ('+ this.players[this.active].role +') is the new active player');
+        info('Player #' +this._state.active+' ('+ this._state.players[this._state.active].role +') is the new active player');
 
         // Send the play message to the newly activated player
-        this.players[this.active].socket.send({
+        this._state.players[this._state.active].socket.send({
             type: 'message',
-            dstId: this.players[this.active].role,
+            dstId: this._state.players[this._state.active].role,
             msgType: 'start turn',
             content: {
             }

--- a/src/server/rpc/procedures/n-player/n-player.js
+++ b/src/server/rpc/procedures/n-player/n-player.js
@@ -14,6 +14,7 @@ var R = require('ramda'),
  * @return {undefined}
  */
 var NPlayer = function() {
+    this._state = {};
     this._state.active = null;
     this._state.previous = null;
     this._state.players = [];

--- a/src/server/rpc/procedures/simple-hangman/simple-hangman.js
+++ b/src/server/rpc/procedures/simple-hangman/simple-hangman.js
@@ -25,9 +25,9 @@ var debug = require('debug'),
     trace = debug('netsblox:rpc:simple-hangman:trace');
 
 var SimpleHangman = function() {
-    this.word = null;
-    this.wrongGuesses = 0;
-    this.knownIndices = [];
+    this._state.word = null;
+    this._state.wrongGuesses = 0;
+    this._state.knownIndices = [];
 
     this._restart();
 };
@@ -43,13 +43,13 @@ SimpleHangman.prototype.restart = function() {
 };
 
 SimpleHangman.prototype.getCurrentlyKnownWord = function() {
-    var letters = this.word.split('').map(() => '_');
+    var letters = this._state.word.split('').map(() => '_');
 
-    this.knownIndices.forEach(function(index) {
-        letters[index] = this.word[index];
+    this._state.knownIndices.forEach(function(index) {
+        letters[index] = this._state.word[index];
     }, this);
     trace('Currently known word is "'+letters.join(' ')+'"');
-    trace('word is '+this.word);
+    trace('word is '+this._state.word);
     return letters.join(' ');
 };
 
@@ -59,22 +59,22 @@ SimpleHangman.prototype.guess = function(letter) {
 
     letter = letter[0];
     trace('Guessing letter: '+letter);
-    indices = SimpleHangman.getAllIndices(this.word, letter);
-    added = SimpleHangman.merge(this.knownIndices, indices);
+    indices = SimpleHangman.getAllIndices(this._state.word, letter);
+    added = SimpleHangman.merge(this._state.knownIndices, indices);
     if (added === 0) {
-        this.wrongGuesses++;
+        this._state.wrongGuesses++;
     }
     return indices;
 };
 
 SimpleHangman.prototype.isWordGuessed = function() {
-    var isComplete = this.word.length === this.knownIndices.length;
+    var isComplete = this._state.word.length === this._state.knownIndices.length;
     return isComplete;
 };
 
 SimpleHangman.prototype.getWrongCount = function() {
-    trace('wrong count is '+this.wrongGuesses);
-    return this.wrongGuesses;
+    trace('wrong count is '+this._state.wrongGuesses);
+    return this._state.wrongGuesses;
 };
 
 // Private
@@ -85,9 +85,9 @@ SimpleHangman.prototype.getWrongCount = function() {
  */
 SimpleHangman.prototype._restart = function() {
     var index = Math.floor(Math.random()*words.length);
-    this.word = words[index];
-    this.wrongGuesses = 0;
-    this.knownIndices = [];
+    this._state.word = words[index];
+    this._state.wrongGuesses = 0;
+    this._state.knownIndices = [];
 };
 
 SimpleHangman.getAllIndices = function(word, letter) {

--- a/src/server/rpc/procedures/simple-hangman/simple-hangman.js
+++ b/src/server/rpc/procedures/simple-hangman/simple-hangman.js
@@ -25,6 +25,7 @@ var debug = require('debug'),
     trace = debug('netsblox:rpc:simple-hangman:trace');
 
 var SimpleHangman = function() {
+    this._state = {};
     this._state.word = null;
     this._state.wrongGuesses = 0;
     this._state.knownIndices = [];

--- a/src/server/rpc/procedures/static-map/static-map.js
+++ b/src/server/rpc/procedures/static-map/static-map.js
@@ -30,6 +30,7 @@ var baseUrl = 'https://maps.googleapis.com/maps/api/staticmap',
     };
 
 var StaticMap = function(roomId) {
+    this._state = {};
     this._state.roomId = roomId;
     this._state.userMaps = {};  // Store the state of the map for each user
 };

--- a/src/server/rpc/procedures/static-map/static-map.js
+++ b/src/server/rpc/procedures/static-map/static-map.js
@@ -30,8 +30,8 @@ var baseUrl = 'https://maps.googleapis.com/maps/api/staticmap',
     };
 
 var StaticMap = function(roomId) {
-    this.roomId = roomId;
-    this.userMaps = {};  // Store the state of the map for each user
+    this._state.roomId = roomId;
+    this._state.userMaps = {};  // Store the state of the map for each user
 };
 
 StaticMap.getPath = function() {
@@ -56,7 +56,7 @@ StaticMap.prototype._getGoogleParams = function(options) {
 };
 
 StaticMap.prototype._getMapInfo = function(roleId) {
-    return getStorage().get(this.roomId)
+    return getStorage().get(this._state.roomId)
         .then(maps => {
             trace(`getting map for ${roleId}: ${JSON.stringify(maps)}`);
             return maps[roleId];
@@ -87,11 +87,11 @@ StaticMap.prototype._recordUserMap = function(socket, options) {
             width: options.width
         };
 
-    return getStorage().get(this.roomId)
+    return getStorage().get(this._state.roomId)
         .then(maps => {
             maps = maps || {};
             maps[socket.roleId] = map;
-            getStorage().save(this.roomId, maps);
+            getStorage().save(this._state.roomId, maps);
         })
         .then(() => trace(`Stored map for ${socket.roleId}: ${JSON.stringify(map)}`));
 };

--- a/src/server/rpc/procedures/twenty-questions/twenty-questions.js
+++ b/src/server/rpc/procedures/twenty-questions/twenty-questions.js
@@ -9,6 +9,7 @@ var debug = require('debug'),
     Constants = require('../../../../common/constants');
 
 let TwentyQuestions = function () {
+    this._state = {};
     this._state.correctAnswer = null;
     this._state.guessCount = null;
     this._state.answerer = null;

--- a/src/server/rpc/procedures/utils/turn-based.js
+++ b/src/server/rpc/procedures/utils/turn-based.js
@@ -5,7 +5,8 @@ var getArgs = require('../../../server-utils').getArgumentsFor;
 class TurnBased {
 
     constructor(action, reset) {
-        this._lastRoleToAct = null;
+        this._state = {};
+        this._state._lastRoleToAct = null;
         this._rawAction = this[action];
 
         // replace "action" w/ a modified version
@@ -14,7 +15,7 @@ class TurnBased {
                 success;
 
             // Filter
-            if (this._lastRoleToAct === socket.roleId) {
+            if (this._state._lastRoleToAct === socket.roleId) {
                 return this.response.status(403).send('It\'s not your turn!');
             }
 
@@ -26,9 +27,9 @@ class TurnBased {
                 socket._room.sockets().forEach(s => s.send({
                     type: 'message',
                     msgType: 'your turn',
-                    dstId: this._lastRoleToAct
+                    dstId: this._state._lastRoleToAct
                 }));
-                this._lastRoleToAct = socket.roleId;
+                this._state._lastRoleToAct = socket.roleId;
             }
         };
         this[action].args = getArgs(this._rawAction);
@@ -38,7 +39,7 @@ class TurnBased {
         this[reset] = function() {
             var success = this._resetAction.apply(this, arguments);
             if (success) {
-                this._lastRoleToAct = null;
+                this._state._lastRoleToAct = null;
             }
         };
         this[reset].args = getArgs(this._resetAction);

--- a/src/server/rpc/rpc-manager.js
+++ b/src/server/rpc/rpc-manager.js
@@ -152,12 +152,7 @@ RPCManager.prototype.handleRPCRequest = function(RPC, req, res) {
         }
 
         // Add the netsblox socket for triggering network messages from an RPC
-        let ctx;
-        if (rpc instanceof ApiConsumer) {
-            ctx = Object.create(rpc);
-        }else {
-            ctx = rpc;
-        }
+        let ctx = Object.create(rpc);
         ctx.socket = SocketManager.getSocket(uuid);
         ctx.response = res;
         if (!ctx.socket) {

--- a/test/server/rpc/procedures/battleship.spec.js
+++ b/test/server/rpc/procedures/battleship.spec.js
@@ -28,7 +28,7 @@ describe('Battleship Tests', function() {
             var len = battleship.shipLength('Battleship');
             assert.equal(len, 4);
         });
-        
+
         it('should be able to query ship names', function() {
             var ships = battleship.allShips();
             assert.equal(ships.length, 5);
@@ -78,7 +78,7 @@ describe('Battleship Tests', function() {
                 battleship.socket.roleId = 'test';
                 battleship.placeShip('destroyer', row, col, 'north');
                 // Check the spots!
-                board = battleship._rpc._boards.test;
+                board = battleship._rpc._state._boards.test;
             });
 
             it('should place destroyer w/ correct name', function() {

--- a/test/server/rpc/procedures/battleship.spec.js
+++ b/test/server/rpc/procedures/battleship.spec.js
@@ -82,12 +82,12 @@ describe('Battleship Tests', function() {
             });
 
             it('should place destroyer w/ correct name', function() {
-                var name = board._ships[row-1][col-1];  // correcting for 1 indexing
+                var name = board._state._ships[row-1][col-1];  // correcting for 1 indexing
                 assert.equal(name, 'destroyer');
             });
 
             it('should place destroyer w/ correct length', function() {
-                var occupied = board._ships
+                var occupied = board._state._ships
                     .reduce((count, row) => count + row.reduce((c, i) => c + !!i, 0), 0);
 
                 assert.equal(occupied, 3);
@@ -104,7 +104,7 @@ describe('Battleship Tests', function() {
                 var oldPosition;
 
                 battleship.placeShip('destroyer', row, col+1, 'west');
-                oldPosition = board._ships[row-1][col-1];  // correcting for 1 indexing
+                oldPosition = board._state._ships[row-1][col-1];  // correcting for 1 indexing
                 assert.notEqual(oldPosition, 'destroyer');
             });
         });

--- a/test/server/rpc/procedures/connectn.spec.js
+++ b/test/server/rpc/procedures/connectn.spec.js
@@ -19,7 +19,7 @@ describe('ConnectN Tests', function() {
             var board;
 
             connectn.newGame(-4),
-            board = connectn._rpc.board;
+            board = connectn._rpc._state.board;
             assert.equal(board.length, 3);
         });
 
@@ -27,12 +27,12 @@ describe('ConnectN Tests', function() {
             var board;
 
             connectn.newGame(null, -4);
-            board = connectn._rpc.board;
+            board = connectn._rpc._state.board;
             assert.equal(board[0].length, 3);
         });
 
         it('should default to 3 rows; 3 columns', function() {
-            var board = connectn._rpc.board;
+            var board = connectn._rpc._state.board;
 
             connectn.newGame();
             assert.equal(board.length, 3);
@@ -58,7 +58,7 @@ describe('ConnectN Tests', function() {
         it('should not play if winner is found', function() {
             var result;
 
-            connectn._rpc._winner = 'cat';
+            connectn._rpc._state._winner = 'cat';
             connectn.socket.roleId = 'p1';
 
             result = connectn.play(3, -1);

--- a/test/server/rpc/procedures/simplehangman.spec.js
+++ b/test/server/rpc/procedures/simplehangman.spec.js
@@ -7,7 +7,7 @@ describe('simple hangman', function() {
 
     beforeEach(function() {
         hangman = new RPCMock(SimpleHangman);
-        hangman._rpc.word = 'battleship';
+        hangman._rpc._state.word = 'battleship';
     });
 
     utils.verifyRPCInterfaces(hangman, [
@@ -25,19 +25,19 @@ describe('simple hangman', function() {
 
         it('should reset word', function() {
             hangman.restart();
-            assert.notEqual(hangman._rpc.word, 'battleship');
+            assert.notEqual(hangman._rpc._state.word, 'battleship');
         });
 
         it('should reset wrong guesses', function() {
-            hangman._rpc.wrongGuesses = 100;
+            hangman._rpc._state.wrongGuesses = 100;
             hangman.restart();
-            assert.equal(hangman._rpc.wrongGuesses, 0);
+            assert.equal(hangman._rpc._state.wrongGuesses, 0);
         });
 
         it('should reset known indices', function() {
-            hangman._rpc.knownIndices = [1,2,3];
+            hangman._rpc._state.knownIndices = [1,2,3];
             hangman.restart();
-            assert.equal(hangman._rpc.knownIndices.length, 0);
+            assert.equal(hangman._rpc._state.knownIndices.length, 0);
         });
     });
 
@@ -45,7 +45,7 @@ describe('simple hangman', function() {
 
         it('should replace unknown letters w/ _', function() {
             var displayedWord;
-            hangman._rpc.knownIndices = [1, 3, 5, 7];
+            hangman._rpc._state.knownIndices = [1, 3, 5, 7];
             displayedWord = hangman.getCurrentlyKnownWord();
             assert.equal(displayedWord, '_a_t_e_h__'.split('').join(' '));
         });
@@ -55,18 +55,18 @@ describe('simple hangman', function() {
 
         describe('incorrect', function() {
             it('should increment wrong guesses', function() {
-                var oldBadGuesses = hangman._rpc.wrongGuesses;
+                var oldBadGuesses = hangman._rpc._state.wrongGuesses;
                 hangman.guess('z');
-                assert.equal(hangman._rpc.wrongGuesses, oldBadGuesses+1);
+                assert.equal(hangman._rpc._state.wrongGuesses, oldBadGuesses+1);
             });
 
         });
 
         describe('correct', function() {
             it('should not increment wrong guesses', function() {
-                var oldBadGuesses = hangman._rpc.wrongGuesses;
+                var oldBadGuesses = hangman._rpc._state.wrongGuesses;
                 hangman.guess('a');
-                assert.equal(hangman._rpc.wrongGuesses, oldBadGuesses);
+                assert.equal(hangman._rpc._state.wrongGuesses, oldBadGuesses);
             });
 
             it('should update the display word', function() {
@@ -82,7 +82,7 @@ describe('simple hangman', function() {
 
     describe('isWordGuessed', function() {
         it('should return true if entire word has been guessed', function() {
-            var letters = hangman._rpc.word.split('');
+            var letters = hangman._rpc._state.word.split('');
 
             letters.forEach(letter => hangman.guess(letter));
             assert(hangman.isWordGuessed());
@@ -91,7 +91,7 @@ describe('simple hangman', function() {
 
     describe('getWrongCount', function() {
         it('should return the wrongGuesses value', function() {
-            hangman._rpc.wrongGuesses = 100;
+            hangman._rpc._state.wrongGuesses = 100;
             assert.equal(hangman.getWrongCount(), 100);
         });
     });

--- a/test/server/rpc/procedures/twentyquestions.spec.js
+++ b/test/server/rpc/procedures/twentyquestions.spec.js
@@ -4,11 +4,11 @@ describe('twentyquestions', function() {
         utils = require('../../../assets/utils'),
         twentyquestions = new RPCMock(TwentyQuestions),
         assert = require('assert');
-    
+
     before(function () {
         twentyquestions = new RPCMock(TwentyQuestions);
     });
-    
+
     utils.verifyRPCInterfaces(twentyquestions, [
         ['start', ['answer']],
         ['guess', ['guess']],
@@ -16,7 +16,7 @@ describe('twentyquestions', function() {
         ['gameStarted'],
         ['restart']
     ]);
-    
+
     describe('basic command without role', function () {
         it ('can restart the game', function () {
             twentyquestions.restart();
@@ -25,34 +25,34 @@ describe('twentyquestions', function() {
             twentyquestions.gameStarted();
         });
     });
-    
+
     describe('twenty questions', function () {
         beforeEach(function () {
             twentyquestions.restart();
         });
-        
+
         describe('errors', function () {
             it('should return false when restarting a game', function () {
                 assert.equal(twentyquestions.restart(), false);
             });
-            
+
             it('should return an error when starting a started game', function () {
                 twentyquestions.start('books');
                 assert.equal(twentyquestions.start('books'), 'Game has already started...');
             });
-    
+
             it('should return an error when entering invalid answer', function () {
                 assert.equal(twentyquestions.start(''), 'No answer received');
             });
-            
+
             it ('should return an error when guessing before game started', function () {
                 assert.equal(twentyquestions.guess('books'), 'Game hasn\'t started yet...wait for the answerer to think of something!');
             });
-    
+
             it ('should return an error when answering before game started', function () {
                 assert.equal(twentyquestions.answer('yes').response, 'Game hasn\'t started yet...think of something to be guessed!');
             });
-            
+
             describe('for answerer', function () {
                 beforeEach(function () {
                     twentyquestions.start('books');
@@ -60,12 +60,12 @@ describe('twentyquestions', function() {
                 it ('should return an error when guessing as an answerer', function () {
                     assert.equal(twentyquestions.guess('books'), 'You\'re not the guesser!');
                 });
-    
+
                 it ('should return an error when invalid answer', function () {
                     assert.equal(twentyquestions.answer('y').response, 'Answer the guess with yes/no!');
                 });
             });
-    
+
             describe('for guesser', function () {
                 beforeEach(function () {
                     twentyquestions.socket.roleId = 'answerer';
@@ -80,7 +80,7 @@ describe('twentyquestions', function() {
                 });
             });
         });
-        
+
         describe('game started', function () {
             function switchRole () {
                 if (twentyquestions.socket.roleId === 'guesser') {
@@ -94,11 +94,11 @@ describe('twentyquestions', function() {
                 twentyquestions.socket.roleId = 'answerer';
                 twentyquestions.start('book shelf');
             });
-            
+
             it ('end answerer\'s turn', function () {
                 assert.equal(twentyquestions.answer('yes'), true);
             });
-            
+
             describe('for answerer', function () {
                 beforeEach(switchRole);
                 it('end guesser\'s turn', function () {
@@ -108,10 +108,10 @@ describe('twentyquestions', function() {
                     for (let i = 1; i <= 5; i++) {
                         twentyquestions.guess('book');
                     }
-                    assert.equal(twentyquestions._rpc.guessCount, 5);
+                    assert.equal(twentyquestions._rpc._state.guessCount, 5);
                 });
             });
         });
     });
-    
+
 });


### PR DESCRIPTION
Refactored the services to store their state under _state to allow for separate objects per request. This should eliminate issues with race conditions regarding `response`
thanks to @ellienguyen for the help

passing tests should show that the services are operational after this change. We should go through the examples to make sure they are functional