### PR TITLE
exclude outliers on *history methods for eclipse rpc Fixes #1411

### DIFF
--- a/src/server/rpc/procedures/eclipse-2017/eclipse-2017.js
+++ b/src/server/rpc/procedures/eclipse-2017/eclipse-2017.js
@@ -146,7 +146,7 @@ let pastCondition = function(stationId, time){
 let temperatureHistory = function(stationId, limit){
     limit = parseInt(limit);
     if (limit > 3000) limit = 3000;
-    return getReadingsCol().find({pws: stationId}).sort({requestTime: -1})
+    return getReadingsCol().find({pws: stationId}).sort({readAt: -1, requestTime: -1})
         .limit(limit).toArray().then(updates => {
             return updates.map(update => update.temp);
         });
@@ -155,7 +155,7 @@ let temperatureHistory = function(stationId, limit){
 let conditionHistory = function(stationId, limit){
     limit = parseInt(limit);
     if (limit > 3000) limit = 3000;
-    return getReadingsCol().find({pws: stationId}).sort({requestTime: -1})
+    return getReadingsCol().find({pws: stationId}).sort({readAt: -1, requestTime: -1})
         .limit(limit).toArray().then(updates => {
             return rpcUtils.jsonToSnapList(updates.map(update => hideDBAttrs(update)));
         });


### PR DESCRIPTION
When using the tempHistory and conditionHistory methods we get the latest database records based on based on requestTime only. We changed the behaviour from sorting by readAt to requestTime relying on the face that the most recent request will have the most recent sensor value to keep reporting the result of our latests requests.

Sorting first by the time the sensor was read and then our requestTime should solve this issue.
