### PR TITLE
Added default (black) for setColorField. Fixes #1481

### DIFF
--- a/test/client/actions.spec.js
+++ b/test/client/actions.spec.js
@@ -1,0 +1,19 @@
+/* globals driver, SnapActions, Point */
+describe('actions', function() {
+    var position = new Point(600, 600);
+
+    before(function() {
+        driver.reset();
+    });
+
+    it('should have default color w/ setColorField', function(done) {
+        console.log(driver.ide().room.isOwner());
+        var action = driver.addBlock('setColor', position);
+        console.log('action', action);
+        action.accept(block => {
+            console.log(block);
+            SnapActions.setColorField(block.inputs()[0])
+                .accept(() => done());
+        });
+    });
+});

--- a/test/client/index.html
+++ b/test/client/index.html
@@ -27,6 +27,7 @@
   <script src="./messages.spec.js"></script>
   <script src="./services.spec.js"></script>
   <script src="./blocks.spec.js"></script>
+  <script src="./actions.spec.js"></script>
   <script type="text/javascript">
       var world;
       var driver;

--- a/test/client/snap-driver.js
+++ b/test/client/snap-driver.js
@@ -1,3 +1,4 @@
+/* globals SpriteMorph, SnapActions */
 function SnapDriver(world) {
     this._world = world;
 }


### PR DESCRIPTION
I am not sure how this can get called with an undefined color but I know it can happen... maybe on undo?

Regardless, this fix makes sure it doesn't throw an exception and falls back on black. *Note*: the fix is actually in snap-undo but this adds a test and updates the submodule