### PR TITLE
return empty array if the user has no tweets Fixes 1576

### DIFF
--- a/src/server/rpc/procedures/twitter/twitter.js
+++ b/src/server/rpc/procedures/twitter/twitter.js
@@ -47,6 +47,12 @@ module.exports = {
         // repeat as many times as necessary
         var getTweets = () => { 
             request(options, (err, res, body) => {
+                // check if user has any tweets
+                if ( body.length < 1 ) {
+                    // we should set an error status and send a null array
+                    response.send(results);
+                    return;
+                }
                 if (rateCheck(res, response)) {
                     return;
                 }


### PR DESCRIPTION
The response for a  user with no tweets is fixed to be an empty array.

recentTweets is misbehaving as in if the requested user doesn't exist, it returns an empty array where instead it should send an error. 

