### PR TITLE
parse services for jsdoc and present rpc-manger with the metadata Fixes #1605

### DIFF
--- a/package.json
+++ b/package.json
@@ -40,6 +40,7 @@
     "cordova": "^6.1.1",
     "cordova-lib": "^6.1.1",
     "debug": "^2.1.3",
+    "doctrine": "^2.0.0",
     "dot": "^1.1.1",
     "dotenv": "^2.0.0",
     "epipebomb": "^1.0.0",

--- a/src/server/rpc/jsdoc-extractor.js
+++ b/src/server/rpc/jsdoc-extractor.js
@@ -25,14 +25,15 @@ function parseSource(source, searchScope){
     blocks = blocks.filter(block => {
         let linesToSearch = lines.slice(block.endLine, block.endLine + searchScope);
         let fnName;
-        // if @name is set jsut use that and save a few cycles
-        if (block.parsed.tags.some(tag => tag.title === 'name')) {
-            fnName  = block.parsed.tags.find(tag => tag.title === 'name').name;
+        // if @name is set just use that and save a few cycles
+        let nameTag = block.parsed.tags.find(tag => tag.title === 'name');
+        if (nameTag) {
+            fnName  = nameTag.name;
             logger.info('fn name set through @name', fnName);
         } else {
             fnName = findFn(linesToSearch);
             if (!fnName){
-                logger.error(`can't associate ${block.lines} with any function. # Fix it at line ${block.beginLine}, column ${block.column}`);
+                logger.warn(`can't associate ${block.lines} with any function. # Fix it at line ${block.beginLine}, column ${block.column}`);
                 return false;
             }
         }

--- a/src/server/rpc/jsdoc-extractor.js
+++ b/src/server/rpc/jsdoc-extractor.js
@@ -1,0 +1,162 @@
+const fse = require('fs-extra'),
+    doctrine = require('doctrine');
+
+
+const MARKER_START = '/**',
+    MARKER_START_SKIP = '/***',
+    MARKER_END = '*/';
+
+let parse = (filePath, SEARCH_SIZE = 5) => {
+    return fse.readFile(FILE, 'UTF8')
+        .then(source => {
+            let lines = source.split(/\n/);
+            let blocks = extractDocBlocks(source);
+            blocks = blocks.map(block => {
+                let src = block.lines.join('\n');
+                block.parsed = doctrine.parse(src, {unwrap: true});
+                delete block.lines;
+                return block;
+            });
+            blocks.forEach(block => {
+                let linesToSearch = lines.slice(block.endLine, block.endLine + SEARCH_SIZE);
+                // if @name is set jsut use that and save a few cycles
+                if (block.parsed.tags.some(tag => tag.title === 'name')) {
+                    block.fnName  = block.parsed.tags.find(tag => tag.title === 'name').name;
+                    console.log('fn name set through @name', block.fnName);
+                } else {
+                    let fnName = findFn(linesToSearch);
+                    if (!fnName){
+                        throw `can't associate ${block} with any function`;
+                        // TODO filter / ignore this one and keep going
+                    }
+                    block.fnName = fnName;
+                }
+            });
+            console.log(blocks.map(b => b.parsed.tags));
+        })
+        .catch(err => {
+            console.error(err);
+        });
+};
+
+// returns the first function found the a line or an array of lines
+function findFn(line){
+    let fnName;
+    if (Array.isArray(line)) {
+        line.some(ln => {
+            let fn = findFn(ln);
+            if (fn) {
+                fnName = fn;
+                return true;
+            }
+        });
+        return fnName;
+    }
+    // regexlist to find the fn name in format of [regex string, mathgroup]
+    const regexList = [
+        [/function (\w+)\(/, 1],
+        [/\w+\.(\w+).*=.*(function|=>)/, 1],
+        [/(let|var) (\w+) *= *(\w|\().*=>/, 2]
+    ];
+
+    // use array.some to break the loop early
+    regexList.some( regGrp => {
+        let [regex, group] = regGrp;
+        let match = line.match(regex);
+        if (match){
+            fnName = match[group];
+            return true;
+        } 
+    });
+
+    return fnName;
+}
+
+function extractDocBlocks(source){
+    var block;
+    var blocks = [];
+    var extract = mkextract();
+    var lines = source.split(/\n/);
+
+    for (var i = 0, l = lines.length; i < l; i++) {
+        block = extract(lines.shift());
+        if (block) {
+            blocks.push(block);
+        }
+    }
+
+    return blocks;
+}
+
+// credit: https://github.com/yavorskiy/comment-parser
+function mkextract () {
+    var chunk = null;
+    var indent = 0;
+    var number = 1;
+
+    /**
+     * Read lines until they make a block
+     * Return parsed block once fullfilled or null otherwise
+     */
+    return function extract (line) {
+        var result = null;
+        var startPos = line.indexOf(MARKER_START);
+        var endPos = line.indexOf(MARKER_END);
+
+        // if open marker detected and it's not skip one
+        if (startPos !== -1 && line.indexOf(MARKER_START_SKIP) !== startPos) {
+            indent = startPos + MARKER_START.length;
+            chunk = {
+                beginLine: number,
+                column: indent +1,
+                lines: []
+            };
+        }
+
+        // if we are on middle of comment block
+        if (chunk) {
+            var lineStart = indent;
+
+            // figure out if we slice from opening marker pos
+            // or line start is shifted to the left
+            // TODO check for tabs?
+            var nonSpaceChar = line.match(/\S/);
+
+            // skip for the first line starting with /** (fresh chunk)
+            // it always has the right indentation
+            if (chunk.length > 0 && nonSpaceChar) {
+                if (nonSpaceChar[0] === '*') {
+                    lineStart = nonSpaceChar.index + 2;
+                } else if (nonSpaceChar.index < indent) {
+                    lineStart = nonSpaceChar.index;
+                }
+            }
+
+            // slice the line until end or until closing marker start
+            chunk.lines.push(
+                line.slice(lineStart -3, line.length)
+            );
+
+            // finalize block if end marker detected
+            if (endPos !== -1) {
+                chunk.endLine = number;
+                result = chunk;
+                chunk = null;
+                indent = 0;
+            }
+        }
+
+        number += 1;
+        return result;
+    };
+}
+
+const FILE= process.argv[2];
+if (FILE) parse();
+
+// public interface
+module.exports = {
+    extractDocBlocks,
+    _findFn:  findFn,
+    parse: parse
+};

--- a/src/server/rpc/jsdoc-extractor.js
+++ b/src/server/rpc/jsdoc-extractor.js
@@ -29,9 +29,9 @@ function simplify(metadata, associatedFn) {
     let returns = tags.find(tag => tag.title === 'returns');
     if (returns) returns = {type: returns.type.name, description: returns.description};
 
-    let simplified = {description, args, returns};
-    if (associatedFn) simplified.fnName = associatedFn;
+    let name = tags.find(tag => tag.title === 'name').name;
 
+    let simplified = {name, description, args, returns};
     return simplified;
 }
 
@@ -51,7 +51,6 @@ function parseSource(source, searchScope){
         let nameTag = block.parsed.tags.find(tag => tag.title === 'name');
         if (nameTag) {
             fnName  = nameTag.name;
-            block.parsed.tags = block.parsed.tags.filter(tag => tag.title !== 'name');
             logger.info('fn name set through @name', fnName);
         } else {
             fnName = findFn(linesToSearch);
@@ -59,6 +58,7 @@ function parseSource(source, searchScope){
                 logger.warn(`can't associate ${block.lines} with any function. # Fix it at line ${block.beginLine}, column ${block.column}`);
                 return false;
             }
+            block.parsed.tags.push({title: 'name', name: fnName, description: null});
         }
         block.fnName = fnName;
         return true;

--- a/src/server/rpc/jsdoc-extractor.js
+++ b/src/server/rpc/jsdoc-extractor.js
@@ -15,9 +15,11 @@ let parseSync = (filePath, searchScope = 5) => {
 
 //simplifies a single metadata returned by doctrine to be used within netsblox
 function simplify(metadata) {
-    let simplifyParam = tag => {
-        let {name, type, description} = tag;
-        return {name, type: type.name, description};
+    let simplifyParam = param => {
+        let {name, type, description} = param;
+        let simpleParam = {name, description};
+        simpleParam.type = type ? type.name : null;
+        return simpleParam;
     };
     let {description, tags} = metadata;
     let args = tags
@@ -185,15 +187,9 @@ module.exports = {
     _simplify: simplify,
     parse: function(path, scope){
         return parseSync(path, scope)
-            .filter(md => {
-                try {
+            .map(md => {
                     md.parsed = simplify(md.parsed);
-                    return true;
-                } catch (e) {
-                    logger.warn('invalid rpc jsdoc block', md);
-                    // TODO throw the error if you want to enforce this structure on added jdoc blocks
-                    return false;
-                }
-            });
+                    return md;
+                });
     }
 };

--- a/src/server/rpc/jsdoc-extractor.js
+++ b/src/server/rpc/jsdoc-extractor.js
@@ -181,5 +181,19 @@ function mkextract () {
 module.exports = {
     extractDocBlocks,
     _findFn:  findFn,
-    parse: parseSync
+    _parseSource: parseSource,
+    _simplify: simplify,
+    parse: function(path, scope){
+        return parseSync(path, scope)
+            .filter(md => {
+                try {
+                    md.parsed = simplify(md.parsed, md.fnName);
+                    return true;
+                } catch (e) {
+                    logger.warn('invalid rpc jsdoc block', md);
+                    // TODO throw the error if you want to enforce this structure on added jdoc blocks
+                    return false;
+                }
+            });
+    }
 };

--- a/src/server/rpc/jsdoc-extractor.js
+++ b/src/server/rpc/jsdoc-extractor.js
@@ -83,7 +83,7 @@ function findFn(line){
     // regexlist to find the fn name in format of [regex string, mathgroup]
     const regexList = [
         [/function (\w+)\(/, 1],
-        [/\w+\.(\w+).*=.*(function|=>)/, 1],
+        [/\w+\.(\w+)[\w\s]*=.*(function|=>)/, 1],
         [/(let|var) (\w+) *= *(\w|\().*=>/, 2]
     ];
 

--- a/src/server/rpc/jsdoc-extractor.js
+++ b/src/server/rpc/jsdoc-extractor.js
@@ -34,7 +34,6 @@ function parseSource(source, searchScope){
             if (!fnName){
                 logger.error(`can't associate ${block.lines} with any function. # Fix it at line ${block.beginLine}, column ${block.column}`);
                 return false;
-                // TODO filter / ignore this one and keep going
             }
         }
         block.fnName = fnName;
@@ -124,7 +123,6 @@ function mkextract () {
 
             // figure out if we slice from opening marker pos
             // or line start is shifted to the left
-            // TODO check for tabs?
             var nonSpaceChar = line.match(/\S/);
 
             // skip for the first line starting with /** (fresh chunk)
@@ -155,9 +153,6 @@ function mkextract () {
         return result;
     };
 }
-
-const FILE= process.argv[2];
-if (FILE) parse();
 
 // public interface
 module.exports = {

--- a/src/server/rpc/jsdoc-extractor.js
+++ b/src/server/rpc/jsdoc-extractor.js
@@ -13,6 +13,28 @@ let parseSync = (filePath, searchScope = 5) => {
     return parseSource(source, searchScope);
 };
 
+//simplifies a single metadata returned by doctrine to be used within netsblox
+function simplify(metadata, associatedFn) {
+    // TODO attach @name or @fnName
+    let simplifyParam = tag => {
+        let {name, type, description} = tag;
+        return {name, type: type.name, description};
+    };
+    let {description, tags} = metadata;
+    let args = tags
+        .filter(tag => tag.title === 'param')
+        .map(simplifyParam);
+
+    // find and simplify the return doc
+    let returns = tags.find(tag => tag.title === 'returns');
+    if (returns) returns = {type: returns.type.name, description: returns.description};
+
+    let simplified = {description, args, returns};
+    if (associatedFn) simplified.fnName = associatedFn;
+
+    return simplified;
+}
+
 function parseSource(source, searchScope){
     let lines = source.split(/\n/);
     let blocks = extractDocBlocks(source);

--- a/src/server/rpc/jsdoc-extractor.js
+++ b/src/server/rpc/jsdoc-extractor.js
@@ -8,20 +8,9 @@ const MARKER_START = '/**',
     MARKER_START_SKIP = '/***',
     MARKER_END = '*/';
 
-let parse = (filePath, searchScope = 5) => {
+let parseSync = (filePath, searchScope = 5) => {
     let source = fse.readFileSync(filePath, 'UTF8');
     return parseSource(source, searchScope);
-};
-
-let parseAsync = (filePath, searchScope = 5) => {
-    return fse.readFile(filePath, 'UTF8')
-        .then(source => {
-            return parseSource(source, searchScope);
-        })
-        .catch(err => {
-            logger.error(err);
-            throw err;
-        });
 };
 
 function parseSource(source, searchScope){
@@ -174,5 +163,5 @@ if (FILE) parse();
 module.exports = {
     extractDocBlocks,
     _findFn:  findFn,
-    parse: parse
+    parse: parseSync
 };

--- a/src/server/rpc/jsdoc-extractor.js
+++ b/src/server/rpc/jsdoc-extractor.js
@@ -51,6 +51,7 @@ function parseSource(source, searchScope){
         let nameTag = block.parsed.tags.find(tag => tag.title === 'name');
         if (nameTag) {
             fnName  = nameTag.name;
+            block.parsed.tags = block.parsed.tags.filter(tag => tag.title !== 'name');
             logger.info('fn name set through @name', fnName);
         } else {
             fnName = findFn(linesToSearch);

--- a/src/server/rpc/jsdoc-extractor.js
+++ b/src/server/rpc/jsdoc-extractor.js
@@ -14,8 +14,7 @@ let parseSync = (filePath, searchScope = 5) => {
 };
 
 //simplifies a single metadata returned by doctrine to be used within netsblox
-function simplify(metadata, associatedFn) {
-    // TODO attach @name or @fnName
+function simplify(metadata) {
     let simplifyParam = tag => {
         let {name, type, description} = tag;
         return {name, type: type.name, description};
@@ -188,7 +187,7 @@ module.exports = {
         return parseSync(path, scope)
             .filter(md => {
                 try {
-                    md.parsed = simplify(md.parsed, md.fnName);
+                    md.parsed = simplify(md.parsed);
                     return true;
                 } catch (e) {
                     logger.warn('invalid rpc jsdoc block', md);

--- a/src/server/rpc/jsdoc-extractor.js
+++ b/src/server/rpc/jsdoc-extractor.js
@@ -1,4 +1,6 @@
 const fse = require('fs-extra'),
+    Logger = require('../logger.js'),
+    logger = new Logger('netsblox:jsdoc'),
     doctrine = require('doctrine');
 
 
@@ -22,7 +24,7 @@ let parse = (filePath, SEARCH_SIZE = 5) => {
                 // if @name is set jsut use that and save a few cycles
                 if (block.parsed.tags.some(tag => tag.title === 'name')) {
                     block.fnName  = block.parsed.tags.find(tag => tag.title === 'name').name;
-                    console.log('fn name set through @name', block.fnName);
+                    logger.info('fn name set through @name', block.fnName);
                 } else {
                     let fnName = findFn(linesToSearch);
                     if (!fnName){
@@ -32,10 +34,10 @@ let parse = (filePath, SEARCH_SIZE = 5) => {
                     block.fnName = fnName;
                 }
             });
-            console.log(blocks.map(b => b.parsed.tags));
+            logger.log(blocks.map(b => b.parsed.tags));
         })
         .catch(err => {
-            console.error(err);
+            logger.error(err);
         });
 };
 

--- a/src/server/rpc/procedures/geolocation/geolocation.js
+++ b/src/server/rpc/procedures/geolocation/geolocation.js
@@ -59,9 +59,9 @@ if(!process.env.GOOGLE_GEOCODING_API) {
 
 
     /**
-     * Geolocates the address and sends back the coordinates
+     * Geolocates the address and returns the coordinates
      * @param {string} address target address
-     * @returns {structuredData}
+     * @returns {object}
      */
 
     GeoLocationRPC.geolocate = function (address) {

--- a/src/server/rpc/procedures/geolocation/geolocation.js
+++ b/src/server/rpc/procedures/geolocation/geolocation.js
@@ -59,8 +59,9 @@ if(!process.env.GOOGLE_GEOCODING_API) {
 
 
     /**
-     * geolocate and address and send back the details
+     * Geolocates the address and sends back the coordinates
      * @param {string} address target address
+     * @returns {structuredData}
      */
 
     GeoLocationRPC.geolocate = function (address) {

--- a/src/server/rpc/procedures/geolocation/geolocation.js
+++ b/src/server/rpc/procedures/geolocation/geolocation.js
@@ -58,7 +58,11 @@ if(!process.env.GOOGLE_GEOCODING_API) {
     };
 
 
-    // geocode an address and send back the details
+    /**
+     * geolocate and address and send back the details
+     * @param {string} address target address
+     */
+
     GeoLocationRPC.geolocate = function (address) {
         let response = this.response;
 

--- a/src/server/rpc/procedures/geolocation/geolocation.js
+++ b/src/server/rpc/procedures/geolocation/geolocation.js
@@ -60,8 +60,8 @@ if(!process.env.GOOGLE_GEOCODING_API) {
 
     /**
      * Geolocates the address and returns the coordinates
-     * @param {string} address target address
-     * @returns {object}
+     * @param {String} address target address
+     * @returns {Object}
      */
 
     GeoLocationRPC.geolocate = function (address) {

--- a/src/server/rpc/rpc-manager.js
+++ b/src/server/rpc/rpc-manager.js
@@ -97,9 +97,7 @@ RPCManager.prototype.registerRPC = function(rpc) {
         let doc = rpc._docs.find(doc => doc.fnName === fnNames[i]);
         // get the argument names ( starting from doc )
         if (doc) {
-            args = doc.parsed.tags
-                .filter(tag => tag.title === 'param')
-                .map(tag => tag.name);
+            args = doc.parsed.args.map(arg => arg.name);
         }else{
             args = utils.getArgumentsFor(fnObj[fnNames[i]]);
         }

--- a/src/server/rpc/rpc-manager.js
+++ b/src/server/rpc/rpc-manager.js
@@ -92,7 +92,18 @@ RPCManager.prototype.registerRPC = function(rpc) {
         .filter(name => !RESERVED_FN_NAMES.includes(name));
 
     for (var i = fnNames.length; i--;) {
-        this.rpcRegistry[name][fnNames[i]] = utils.getArgumentsFor(fnObj[fnNames[i]]);
+        let args;
+        // find the associated doc
+        let doc = rpc._docs.find(doc => doc.fnName === fnNames[i]);
+        // get the argument names ( starting from doc )
+        if (doc) {
+            args = doc.parsed.tags
+                .filter(tag => tag.title === 'param')
+                .map(tag => tag.name);
+        }else{
+            args = utils.getArgumentsFor(fnObj[fnNames[i]]);
+        }
+        this.rpcRegistry[name][fnNames[i]] = args;
     }
 };
 

--- a/src/server/rpc/rpc-manager.js
+++ b/src/server/rpc/rpc-manager.js
@@ -60,8 +60,6 @@ RPCManager.prototype.loadRPCs = function() {
         })
         .map(pair => {
             let [name, RPCConstructor] = pair;
-            // console.log(RPCConstructor._docs);
-            // console.log(Object.keys(RPCConstructor));
             if (RPCConstructor.init) {
                 RPCConstructor.init(this._logger);
             }

--- a/src/server/rpc/rpc-manager.js
+++ b/src/server/rpc/rpc-manager.js
@@ -94,7 +94,7 @@ RPCManager.prototype.registerRPC = function(rpc) {
     for (var i = fnNames.length; i--;) {
         let args;
         // find the associated doc
-        let doc = rpc._docs.find(doc => doc.fnName === fnNames[i]);
+        let doc = rpc._docs.find(doc => doc.parsed.name === fnNames[i]);
         // get the argument names ( starting from doc )
         if (doc) {
             args = doc.parsed.args.map(arg => arg.name);

--- a/test/server/rpc/jsdoc-extractor.spec.js
+++ b/test/server/rpc/jsdoc-extractor.spec.js
@@ -4,7 +4,7 @@ const assert = require('assert'),
 
 describe('jsdoc-extractor', () => {
 
-    describe.only('fnFinder', () => {
+    describe('fnFinder', () => {
         let testText = `let doStuff = a => a*2;
     function doStuff(){}
     GoogleMap.doStuff = function
@@ -21,7 +21,12 @@ describe('jsdoc-extractor', () => {
             assert.deepEqual(jp._findFn(line), 'reverseGeocode');
         });
 
-        it('should fiind obj.ojb = function', () => {
+        it('should find let fn = arg => ', () => {
+            let line = 'let reverseGeocode = arg=>{';
+            assert.deepEqual(jp._findFn(line), 'reverseGeocode');
+        });
+
+        it('should find obj.obj = function', () => {
             let line = '    GeoLocationRPC.geolocate = function (address) {';
             assert.deepEqual(jp._findFn(line), 'geolocate');
         });

--- a/test/server/rpc/jsdoc-extractor.spec.js
+++ b/test/server/rpc/jsdoc-extractor.spec.js
@@ -41,6 +41,11 @@ describe('jsdoc-extractor', () => {
             let line = '    GeoLocationRPC.geolocate = function (address) {';
             assert.deepEqual(jp._findFn(line), 'geolocate');
         });
+
+        it('should know prototype is not the fn name', () => {
+            let line = 'Googlemap.prototype.doStuff = function';
+            assert.deepEqual(jp._findFn(line), 'doStuff');
+        });
     });
 
 

--- a/test/server/rpc/jsdoc-extractor.spec.js
+++ b/test/server/rpc/jsdoc-extractor.spec.js
@@ -1,0 +1,30 @@
+const assert = require('assert'),
+    utils = require('../../assets/utils.js'),
+    jp = utils.reqSrc('rpc/jsdoc-extractor.js');
+
+describe('jsdoc-extractor', () => {
+
+    describe.only('fnFinder', () => {
+        let testText = `let doStuff = a => a*2;
+    function doStuff(){}
+    GoogleMap.doStuff = function
+    GoogleMap.doStuff = (asdf) =>`;
+
+        let testLines = testText.split('\n');
+
+        it('should support multiline', () => {
+            assert.deepEqual(jp._findFn(testLines[2]), 'doStuff');
+        });
+
+        it('should find let fn = ()', () => {
+            let line = 'let reverseGeocode = (lat, lon, response, query)=>{';
+            assert.deepEqual(jp._findFn(line), 'reverseGeocode');
+        });
+
+        it('should fiind obj.ojb = function', () => {
+            let line = '    GeoLocationRPC.geolocate = function (address) {';
+            assert.deepEqual(jp._findFn(line), 'geolocate');
+        });
+    });
+
+});

--- a/test/server/rpc/jsdoc-extractor.spec.js
+++ b/test/server/rpc/jsdoc-extractor.spec.js
@@ -8,11 +8,11 @@ describe('jsdoc-extractor', () => {
     /**
      * this is the description
      * next line of description
-     * @param {string} address target address
-     * @param {number} limit the results limit
+     * @param {String} address target address
+     * @param {Number} limit the results limit
      * @param {Object} options
      * @name doStuff
-     * @returns {string}
+     * @returns {String}
      * @name associatedFnName
      */
     `;
@@ -66,12 +66,12 @@ describe('jsdoc-extractor', () => {
                 args: [
                     {
                         name: 'address',
-                        type: 'string',
+                        type: 'String',
                         description: 'target address'
                     },
                     {
                         name: 'limit',
-                        type: 'number',
+                        type: 'Number',
                         description: 'the results limit'
                     },
                     {
@@ -80,7 +80,7 @@ describe('jsdoc-extractor', () => {
                         description: null
                     }
                 ],
-                returns: {type: 'string', description: null}
+                returns: {type: 'String', description: null}
             });
         });
     });

--- a/test/server/rpc/jsdoc-extractor.spec.js
+++ b/test/server/rpc/jsdoc-extractor.spec.js
@@ -11,6 +11,7 @@ describe('jsdoc-extractor', () => {
      * @param {string} address target address
      * @param {number} limit the results limit
      * @param {Object} options
+     * @name doStuff
      * @returns {string}
      * @name associatedFnName
      */
@@ -60,6 +61,7 @@ describe('jsdoc-extractor', () => {
         it('should simplify the metadata', () => {
             let simpleMetadata = jp._simplify(metadata.parsed);
             assert.deepEqual(simpleMetadata, {
+                name: 'doStuff',
                 description: metadata.parsed.description,
                 args: [
                     {

--- a/test/server/rpc/jsdoc-extractor.spec.js
+++ b/test/server/rpc/jsdoc-extractor.spec.js
@@ -4,12 +4,23 @@ const assert = require('assert'),
 
 describe('jsdoc-extractor', () => {
 
+    let comment = `
+    /**
+     * this is the description
+     * next line of description
+     * @param {string} address target address
+     * @param {number} limit the results limit
+     * @param {Object} options
+     * @returns {string}
+     * @name associatedFnName
+     */
+    `;
+
     describe('fnFinder', () => {
         let testText = `let doStuff = a => a*2;
     function doStuff(){}
     GoogleMap.doStuff = function
     GoogleMap.doStuff = (asdf) =>`;
-
         let testLines = testText.split('\n');
 
         it('should support multiline', () => {
@@ -29,6 +40,41 @@ describe('jsdoc-extractor', () => {
         it('should find obj.obj = function', () => {
             let line = '    GeoLocationRPC.geolocate = function (address) {';
             assert.deepEqual(jp._findFn(line), 'geolocate');
+        });
+    });
+
+
+    describe('parsing', () => {
+
+        let metadata = jp._parseSource(comment)[0];
+
+        it('should parse jsdoc comments', () => {
+            assert.deepEqual(metadata.parsed.tags[1].name, 'limit');
+        }); 
+
+        it('should simplify the metadata', () => {
+            let simpleMetadata = jp._simplify(metadata.parsed);
+            assert.deepEqual(simpleMetadata, {
+                description: metadata.parsed.description,
+                args: [
+                    {
+                        name: 'address',
+                        type: 'string',
+                        description: 'target address'
+                    },
+                    {
+                        name: 'limit',
+                        type: 'number',
+                        description: 'the results limit'
+                    },
+                    {
+                        name: 'options',
+                        type: 'Object',
+                        description: null
+                    }
+                ],
+                returns: {type: 'string', description: null}
+            });
         });
     });
 


### PR DESCRIPTION
- scans services source codes for jsdoc blocks
- parses jsdocs
- finds the associated RPC with the parsed jsdoc
- provides this meta data to the rpc-manager
- + when building the RPCs, grabs the argument names from jsdoc if available 