### PR TITLE
xml for the role should be in cloud format. Fixes #1631

### DIFF
--- a/src/client/netsblox.js
+++ b/src/client/netsblox.js
@@ -1790,7 +1790,12 @@ NetsBloxMorph.prototype.openRoomString = function (str) {
 
     // load the given project
     role = room.children[0];
-    var projectXml = role.children[0].toString() + role.children[1].toString();
+    var projectXml = [
+        '<snapdata>',
+        role.childNamed('project').toString(),
+        role.childNamed('media').toString(),
+        '</snapdata>'
+    ].join('');
     SnapActions.openProject(projectXml);
 };
 


### PR DESCRIPTION
Cloud data is structured slightly differently than the local project data. When loading a room, it was creating the data for the current role incorrectly (cloud data looked like local data). All it needed was to be nested in `<snapdata>` tags to make sure it was parsed as cloud data and not regular `<project>` xml. 