### PR TITLE
cache validity tests Fixes #1137

### DIFF
--- a/test/server/rpc/procedures/utils/api-consumer.spec.js
+++ b/test/server/rpc/procedures/utils/api-consumer.spec.js
@@ -67,7 +67,7 @@ describe('ApiConsumer', function(){
                 // we shouldn't get here, fail the test if we get here
                 throw new Error(errorMsg);
             }).catch(e => {
-                assert.deepEqual(e.name, 'RequestError'); // if this line throws we get a timeout
+                assert.deepEqual(e.name, 'RequestError');
                 done();
             });
         });
@@ -81,7 +81,6 @@ describe('ApiConsumer', function(){
             apiConsumer._requestData(queryOpts).catch( () => {
                 // check if it is cached or not
                 testRpc._rpc._cache.get(queryOpts.baseUrl + queryOpts.queryString, function(err, result) {
-                    // if one of these assertions fail, the exception will be catched by the wrapping func thus we'll get a timeout
                     assert.equal(err,null);
                     assert.equal(result,null);
                     done();

--- a/test/server/rpc/procedures/utils/api-consumer.spec.js
+++ b/test/server/rpc/procedures/utils/api-consumer.spec.js
@@ -20,6 +20,7 @@ describe('ApiConsumer', function(){
     });
 
     describe('requestData', ()=>{
+
         it('should get correct data from the endpoint', done => {
             let queryOpts = {
                 queryString: '/',
@@ -54,5 +55,39 @@ describe('ApiConsumer', function(){
                     });
             });
         });
+
+        it('should throw when requesting a nonexisintg resource', done => {
+            const queryOpts = {
+                queryString: '/',
+                baseUrl: 'http://AAnonexistingdomainadslfjazxcvsadf.com',
+                json: false
+            };
+            const errorMsg = 'this request shouldn\'t resolve';
+            apiConsumer._requestData(queryOpts).then(() => {
+                // we shouldn't get here, fail the test if we get here
+                throw new Error(errorMsg);
+            }).catch(e => {
+                assert.deepEqual(e.name, 'RequestError'); // if this line throws we get a timeout
+                done();
+            });
+        });
+
+        it('should not cache rejected promises', done => {
+            const queryOpts = {
+                queryString: '/',
+                baseUrl: 'http://BBnonexistingdomainadslfjazxcvsadf.com',
+                json: false
+            };
+            apiConsumer._requestData(queryOpts).catch( () => {
+                // check if it is cached or not
+                testRpc._rpc._cache.get(queryOpts.baseUrl + queryOpts.queryString, function(err, result) {
+                    // if one of these assertions fail, the exception will be catched by the wrapping func thus we'll get a timeout
+                    assert.equal(err,null);
+                    assert.equal(result,null);
+                    done();
+                });
+            });
+        });
+
     });
 }); // end of ApiConsumer describe


### PR DESCRIPTION
confirming that rejected promises are not being cached by adding tests