### PR TITLE
Moved action acceptance to the server during collab. Fixes #1230

### DIFF
--- a/src/client/actions.js
+++ b/src/client/actions.js
@@ -65,7 +65,6 @@ SnapActions.isCollaborating = function() {
 
 // Recording user actions
 SnapActions.send = function(event) {
-    var canSend = this._ws && this._ws.readyState === WebSocket.OPEN;
     // Netsblox addition: start
     var socket = this.ide().sockets;
 
@@ -74,9 +73,9 @@ SnapActions.send = function(event) {
     // Netsblox addition: end
     event.id = event.id || this.lastSeen + 1;
     this.lastSent = event.id;
-    if (this.isCollaborating() && event.type !== 'openProject' && canSend) {
+    if (event.type !== 'openProject') {
         // Netsblox addition: start
-        this._ws.send(JSON.stringify({
+        socket.send(JSON.stringify({
             type: 'user-action',
             action: event
         }));

--- a/src/client/room.js
+++ b/src/client/room.js
@@ -121,8 +121,7 @@ RoomMorph.prototype.getCurrentOccupants = function() {
 };
 
 RoomMorph.prototype.isLeader = function() {
-    var leader = this.getCurrentOccupants()[0];
-    return leader && leader.uuid === this.myUuid();
+    return this.getCurrentOccupants().length === 1;
 };
 
 RoomMorph.prototype.myUuid = function() {

--- a/src/client/websockets.js
+++ b/src/client/websockets.js
@@ -249,15 +249,19 @@ WebSocketManager.prototype._connectWebSocket = function() {
     };
 };
 
-WebSocketManager.prototype.sendMessage = function(message) {
+WebSocketManager.prototype.send = function(message) {
     var state = this.websocket.readyState;
-    message.namespace = 'netsblox';
-    message = this.serializeMessage(message);
     if (state === this.websocket.OPEN) {
         this.websocket.send(message);
     } else {
         this.messages.push(message);
     }
+};
+
+WebSocketManager.prototype.sendMessage = function(message) {
+    message.namespace = 'netsblox';
+    message = this.serializeMessage(message);
+    this.send(message);
 };
 
 WebSocketManager.prototype.serializeMessage = function(message) {

--- a/src/server/server-utils.js
+++ b/src/server/server-utils.js
@@ -42,11 +42,11 @@ var serialize = function(service) {
 var serializeRole = (role, project) => {
     const owner = encodeURIComponent(project.owner);
     const name = encodeURIComponent(project.name);
-    const src = role.SourceCode ? 
+    const src = role.SourceCode ?
         `<snapdata>+${encodeURIComponent(role.SourceCode + role.Media)}</snapdata>` :
         '';
     return `RoomName=${name}&Owner=${owner}&` +
-        serialize(R.omit(['SourceCode', 'Media'], role)) + 
+        serialize(R.omit(['SourceCode', 'Media'], role)) +
         `&SourceCode=${src}`;
 };
 
@@ -89,7 +89,7 @@ var extractRpcs = function(projectXml){
         foundRpcs.forEach(txt=>{
             let match = txt.match(/getJSFromRPCStruct"><l>([a-zA-Z\-_0-9]+)<\/l>/);
             services.push(match[1]);
-        });                
+        });
     }
     return services;
 };
@@ -126,6 +126,14 @@ var getEmptyRole = function(name) {
         Media: '',
         MediaSize: 0
     };
+};
+
+var parseActionId = function(src) {
+    const startString = 'collabStartIndex="';
+    const startIndex = src.indexOf(startString);
+    const offset = startIndex + startString.length+1;
+    const endIndex = src.substring(offset).indexOf('"') + offset;
+    return +src.substring(offset-1, endIndex) || 0;
 };
 
 var parseField = function(src, field) {
@@ -215,9 +223,10 @@ module.exports = {
     xml: {
         thumbnail: src => parseField(src, 'thumbnail'),
         notes: src => parseField(src, 'notes'),
+        actionId: parseActionId,
         format: SnapXml.format
     },
     getEmptyRole,
     getArgumentsFor,
-    APP 
+    APP
 };

--- a/test/server/server-utils.js
+++ b/test/server/server-utils.js
@@ -34,4 +34,11 @@ describe('server-utils', function() {
             });
         });
     });
+
+    describe('xml', function() {
+        it('should be able to parse action id', function () {
+            const test = '<project collabStartIndex="10">';
+            assert.equal(utils.xml.actionId(test), 10);
+        });
+    });
 });


### PR DESCRIPTION
This PR moves the acceptance of actions to the server. The last action/commit id is stored in memory and is used to accept/reject any actions that are not made on the most recent version of the project.

The retrieval of the action id is performed async to make any changes to the storage location of the latest action ids easy to modify (important for supporting horizontal scaling or migrating it to a persistent location in the future).