### PR TITLE
removed leftover .only

### DIFF
--- a/test/unit/server/storage/projects.js
+++ b/test/unit/server/storage/projects.js
@@ -1,4 +1,4 @@
-describe.only('projects', function() {
+describe('projects', function() {
     const utils = require('../../../assets/utils');
     const Q = require('q');
     const assert = require('assert');


### PR DESCRIPTION
most of our mocha tests are being ignored because of a leftover .only statement.