### PR TITLE
Added headers from upgrade req to bug report. Fixes #1948

### DIFF
--- a/src/server/bug-reporter.js
+++ b/src/server/bug-reporter.js
@@ -22,6 +22,17 @@ const BugReporter = function() {
 BugReporter.prototype.reportInvalidSocketMessage = function(err, msg, socket) {
     const subject = 'Invalid Socket Message';
     const username = socket.username;
+    const req = socket._socket.upgradeReq;
+    const headerFields = [
+        'user-agent',
+        'sec-websocket-version',
+        'sec-websocket-extensions',
+        'accept-encoding',
+        'accept-language'
+    ];
+    const headers = {};
+    headerFields.forEach(header => headers[header] = req.headers[header]);
+
     const data = {
         filename: 'message.json',
         content: {
@@ -31,6 +42,8 @@ BugReporter.prototype.reportInvalidSocketMessage = function(err, msg, socket) {
             timestamp: new Date(),
             username: username,
             uuid: socket.uuid,
+            reqHeaders: headers,
+            readyState: socket._socket.readyState,
             message: msg
         }
     };


### PR DESCRIPTION
I added the request headers from the original upgrade request (part of the ws spec) so the platform of the given user can be determined on a corrupt websocket message.