### PR TITLE
Moved ping-pong msgs to user-layer. Fixes #1999

### DIFF
--- a/src/server/rooms/netsblox-socket.js
+++ b/src/server/rooms/netsblox-socket.js
@@ -199,7 +199,6 @@ class NetsBloxSocket {
 
         // change the heartbeat to use ping/pong from the ws spec
         this.checkAlive();
-        this._socket.on('pong', () => this.isAlive = true);
 
         // Report the server version
         this.send({
@@ -245,10 +244,14 @@ class NetsBloxSocket {
             this._socket.terminate();
             this.close();
         } else {
-            this._socket.ping();
+            this.ping();
             this.isAlive = false;
             this.nextHeartbeat = setTimeout(this.checkAlive.bind(this), NetsBloxSocket.HEARTBEAT_INTERVAL);
         }
+    }
+
+    ping() {
+        this.send({type: 'ping'});
     }
 
     isSocketOpen() {
@@ -495,6 +498,10 @@ NetsBloxSocket.prototype.CLOSING = 2;
 NetsBloxSocket.prototype.CLOSED = 3;
 
 NetsBloxSocket.MessageHandlers = {
+    'pong': function() {
+        this.isAlive = true;
+    },
+
     'set-uuid': function(msg) {
         this.uuid = msg.body;
         this.username = this.username || this.uuid;


### PR DESCRIPTION
This PR supports client detection of broken websocket connections (https://github.com/NetsBlox/Snap--Build-Your-Own-Blocks/pull/552). Ping messages are only sent if there has not been recent socket activity.