### PR TITLE
Added CloudVariables Service. Closes #1542

### DIFF
--- a/src/server/rpc/procedures/cloud-variables/cloud-variables.js
+++ b/src/server/rpc/procedures/cloud-variables/cloud-variables.js
@@ -1,3 +1,11 @@
+/**
+ * The CloudVariables Service provides support for storing variables on the cloud.
+ * Variables can be optionally password-protected or stored only for the current user.
+ *
+ * Cloud variables that are inactive (no reads or writes) for 30 days are subject to deletion.
+ *
+ * @service
+ */
 const Storage = require('../../storage');
 
 let _collections = null;
@@ -43,6 +51,11 @@ const validateContentSize = function(content) {
 
 const CloudVariables = {};
 
+/**
+ * Get the value of a cloud variable
+ * @param {String} name Variable name
+ * @param {String=} password Password (if password-protected)
+ */
 CloudVariables.getVariable = function(name, password) {
     const {sharedVars} = getCollections();
     const username = this.socket.username;
@@ -66,6 +79,13 @@ CloudVariables.getVariable = function(name, password) {
         });
 };
 
+/**
+ * Set a cloud variable.
+ * If a password is provided on creation, the variable will be password-protected.
+ * @param {String} name Variable name
+ * @param {String} value Value to store in variable
+ * @param {String=} password Password (if password-protected)
+ */
 CloudVariables.setVariable = function(name, value, password) {
     validateVariableName(name);
     validateContentSize(value);
@@ -92,6 +112,11 @@ CloudVariables.setVariable = function(name, value, password) {
         });
 };
 
+/**
+ * Delete a given cloud variable
+ * @param {String} name Variable to delete
+ * @param {String=} password Password (if password-protected)
+ */
 CloudVariables.deleteVariable = function(name, password) {
     const {sharedVars} = getCollections();
     return sharedVars.findOne({name: name})
@@ -103,6 +128,10 @@ CloudVariables.deleteVariable = function(name, password) {
         .then(() => 'OK');
 };
 
+/**
+ * Get the value of a variable for the current user.
+ * @param {String} name Variable name
+ */
 CloudVariables.getUserVariable = function(name) {
     const {userVars} = getCollections();
     const username = this.socket.username;
@@ -124,6 +153,11 @@ CloudVariables.getUserVariable = function(name) {
         });
 };
 
+/**
+ * Set the value of the user cloud variable for the current user.
+ * @param {String} name Variable name
+ * @param {String} value
+ */
 CloudVariables.setUserVariable = function(name, value) {
     ensureLoggedIn(this.socket);
     validateVariableName(name);
@@ -141,6 +175,11 @@ CloudVariables.setUserVariable = function(name, value) {
         .then(() => 'OK');
 };
 
+/**
+ * Delete the user variable for the current user.
+ * @param {String} name Variable name
+ * @param {String} value
+ */
 CloudVariables.deleteUserVariable = function(name) {
     const {userVars} = getCollections();
     const username = this.socket.username;

--- a/src/server/rpc/procedures/cloud-variables/cloud-variables.js
+++ b/src/server/rpc/procedures/cloud-variables/cloud-variables.js
@@ -1,0 +1,154 @@
+const Storage = require('../../storage');
+const NAME = 'CloudVariables';
+const Logger = require('../../../logger');
+const logger = new Logger('netsblox:rpc:cloud-variables');
+
+let _collections = null;
+const getCollections = function() {
+    if (!_collections) {
+        _collections = {};
+        _collections.sharedVars = Storage.create('cloud-variables:shared').collection;
+        _collections.userVars = Storage.create('cloud-variables:user').collection;
+    }
+    return _collections;
+};
+
+const ensureAuthorized = function(variable, password) {
+    if (variable) {
+        const authorized = !variable.password ||
+            variable.password === password;
+
+        if (!authorized) {
+            throw new Error('Unauthorized: incorrect password');
+        }
+    }
+};
+
+const ensureLoggedIn = function(socket) {
+    if (!socket.isLoggedIn()) {
+        throw new Error('Login required.');
+    }
+};
+
+const validateVariableName = function(name) {
+    if (!/^[\w _()-]+$/.test(name)) {
+        throw new Error('Invalid variable name.');
+    }
+};
+
+const validateContentSize = function(content) {
+    const sizeInBytes = content.length*2;  // assuming utf8. Figure ~2 bytes per char
+    const mb = 1024*1024;
+    if (sizeInBytes > (4*mb)) {
+        throw new Error('Variable value is too large.');
+    }
+};
+
+const CloudVariables = {};
+
+CloudVariables.getVariable = function(name, password) {
+    const {sharedVars} = getCollections();
+    const username = this.socket.username;
+
+    return sharedVars.findOne({name: name})
+        .then(variable => {
+            ensureAuthorized(variable, password);
+
+            if (!variable) {
+                throw new Error('Variable not found');
+            }
+
+            const query = {
+                $set: {
+                    lastReader: username,
+                    lastReadTime: new Date(),
+                }
+            };
+            return sharedVars.updateOne({name, password}, query)
+                .then(() => variable.value);
+        });
+};
+
+CloudVariables.setVariable = function(name, value, password) {
+    validateVariableName(name);
+    validateContentSize(value);
+
+    const {sharedVars} = getCollections();
+    const username = this.socket.username;
+
+    return sharedVars.findOne({name: name})
+        .then(variable => {
+            ensureAuthorized(variable, password);
+            // Set both the password and value in case it gets deleted
+            // during this async fn...
+            const query = {
+                $set: {
+                    value,
+                    password,
+                    lastWriter: username,
+                    lastWriteTime: new Date(),
+                }
+            };
+
+            return sharedVars.updateOne({name: name}, query, {upsert: true})
+                .then(() => 'OK');
+        });
+};
+
+CloudVariables.deleteVariable = function(name, password) {
+    const {sharedVars} = getCollections();
+    return sharedVars.findOne({name: name})
+        .then(variable => {
+            ensureAuthorized(variable, password);
+
+            return sharedVars.deleteOne({name, password});
+        });
+};
+
+CloudVariables.getUserVariable = function(name) {
+    const {userVars} = getCollections();
+    const username = this.socket.username;
+
+    ensureLoggedIn(this.socket);
+    return userVars.findOne({name: name, owner: username})
+        .then(variable => {
+            if (!variable) {
+                throw new Error('Variable not found');
+            }
+
+            const query = {
+                $set: {
+                    lastReadTime: new Date(),
+                }
+            };
+            return userVars.updateOne({name, owner: username}, query)
+                .then(() => variable.value);
+        });
+};
+
+CloudVariables.setUserVariable = function(name, value) {
+    ensureLoggedIn(this.socket);
+    validateVariableName(name);
+    validateContentSize(value);
+
+    const {userVars} = getCollections();
+    const username = this.socket.username;
+    const query = {
+        $set: {
+            value,
+            lastWriteTime: new Date(),
+        }
+    };
+    return userVars.updateOne({name, owner: username}, query, {upsert: true})
+        .then(() => 'OK');
+};
+
+CloudVariables.deleteUserVariable = function(name) {
+    const {userVars} = getCollections();
+    const username = this.socket.username;
+
+    ensureLoggedIn(this.socket);
+    return userVars.deleteOne({name: name, owner: username});
+};
+
+module.exports = CloudVariables;

--- a/src/server/rpc/procedures/cloud-variables/cloud-variables.js
+++ b/src/server/rpc/procedures/cloud-variables/cloud-variables.js
@@ -1,7 +1,4 @@
 const Storage = require('../../storage');
-const NAME = 'CloudVariables';
-const Logger = require('../../../logger');
-const logger = new Logger('netsblox:rpc:cloud-variables');
 
 let _collections = null;
 const getCollections = function() {
@@ -102,7 +99,8 @@ CloudVariables.deleteVariable = function(name, password) {
             ensureAuthorized(variable, password);
 
             return sharedVars.deleteOne({name, password});
-        });
+        })
+        .then(() => 'OK');
 };
 
 CloudVariables.getUserVariable = function(name) {
@@ -148,7 +146,8 @@ CloudVariables.deleteUserVariable = function(name) {
     const username = this.socket.username;
 
     ensureLoggedIn(this.socket);
-    return userVars.deleteOne({name: name, owner: username});
+    return userVars.deleteOne({name: name, owner: username})
+        .then(() => 'OK');
 };
 
 module.exports = CloudVariables;

--- a/src/server/rpc/procedures/cloud-variables/cloud-variables.js
+++ b/src/server/rpc/procedures/cloud-variables/cloud-variables.js
@@ -30,7 +30,7 @@ const ensureAuthorized = function(variable, password) {
 };
 
 const ensureLoggedIn = function(socket) {
-    if (!socket.isLoggedIn()) {
+    if (!socket.loggedIn) {
         throw new Error('Login required.');
     }
 };

--- a/test/assets/utils.js
+++ b/test/assets/utils.js
@@ -154,16 +154,7 @@ const reset = function() {
 
     return connect()
         .then(_db => db = _db)
-        .then(() => db.collection('groups').drop())
-        .catch(() => db)
-        .then(() => db.collection('projects').drop())
-        .catch(() => db)
-        .then(() => db.collection('users').drop())
-        .catch(() => db)
-        .then(() => db.collection('project-actions').drop())
-        .catch(() => db)
-        .then(() => db.collection('project-archives').drop())
-        .catch(() => db)
+        .then(() => db.dropDatabase())
         .then(() => fixtures.init(storage))
         .then(() => logger.info('Finished loading test fixtures!'))
         .then(() => storage._db);

--- a/test/unit/server/rpc/procedures/cloud-variables.spec.js
+++ b/test/unit/server/rpc/procedures/cloud-variables.spec.js
@@ -1,0 +1,16 @@
+describe('cloud-variables', function() {
+    const utils = require('../../../../assets/utils');
+    const CloudVariables = utils.reqSrc('rpc/procedures/cloud-variables/cloud-variables');
+    const RPCMock = require('../../../../assets/mock-rpc');
+    const cloudvariables = new RPCMock(CloudVariables);
+
+    utils.verifyRPCInterfaces(cloudvariables, [
+        ['getVariable', ['name', 'password']],
+        ['setVariable', ['name', 'value', 'password']],
+        ['deleteVariable', ['name', 'password']],
+        ['getUserVariable', ['name']],
+        ['setUserVariable', ['name', 'value']],
+        ['deleteUserVariable', ['name']],
+    ]);
+
+});

--- a/test/unit/server/rpc/procedures/cloud-variables.spec.js
+++ b/test/unit/server/rpc/procedures/cloud-variables.spec.js
@@ -23,6 +23,14 @@ describe('cloud-variables', function() {
 
     describe('public', function() {
 
+        it('should not set variables w/ invalid names', function() {
+            try {
+                cloudvariables.setVariable('^#', 'world');
+            } catch(err) {
+                assert(err.message.includes('variable name'));
+            }
+        });
+
         it('should get/set variables', function() {
             const name = newVar();
             return cloudvariables.setVariable(name, 'world')
@@ -64,6 +72,16 @@ describe('cloud-variables', function() {
         beforeEach(function() {
             cloudvariables.socket.loggedIn = true;
             cloudvariables.socket.username = 'brian';
+        });
+
+        it('should not be able to set variables if guest', function() {
+            const name = newVar();
+            cloudvariables.socket.loggedIn = false;
+            try {
+                return cloudvariables.setUserVariable(name, 'world');
+            } catch(err) {
+                assert(err.message.includes('Login required'));
+            }
         });
 
         it('should get/set variables', function() {

--- a/test/unit/server/rpc/procedures/cloud-variables.spec.js
+++ b/test/unit/server/rpc/procedures/cloud-variables.spec.js
@@ -3,6 +3,7 @@ describe('cloud-variables', function() {
     const CloudVariables = utils.reqSrc('rpc/procedures/cloud-variables/cloud-variables');
     const RPCMock = require('../../../../assets/mock-rpc');
     const cloudvariables = new RPCMock(CloudVariables);
+    const assert = require('assert');
 
     utils.verifyRPCInterfaces(cloudvariables, [
         ['getVariable', ['name', 'password']],
@@ -13,4 +14,88 @@ describe('cloud-variables', function() {
         ['deleteUserVariable', ['name']],
     ]);
 
+    let counter = 0;
+    function newVar() {
+        return `var${counter++}`;
+    }
+
+    before(() => utils.reset());
+
+    describe('public', function() {
+
+        it('should get/set variables', function() {
+            const name = newVar();
+            return cloudvariables.setVariable(name, 'world')
+                .then(() => cloudvariables.getVariable(name))
+                .then(result => assert.equal(result, 'world'));
+        });
+
+        it('should delete variables', function() {
+            const name = newVar();
+            return cloudvariables.setVariable(name, 'world')
+                .then(() => cloudvariables.deleteVariable(name))
+                .then(() => cloudvariables.getVariable(name))
+                .catch(err => assert(err.message.includes('not found')));
+        });
+
+        it('should not get/set variables w/ bad password', function() {
+            const name = newVar();
+            return cloudvariables.setVariable(name, 'world', 'password')
+                .then(() => cloudvariables.getVariable(name))
+                .catch(err => assert(err.message.includes('password')));
+        });
+
+        it('should not set variables w/ bad password', function() {
+            const name = newVar();
+            return cloudvariables.setVariable(name, 'world', 'password')
+                .then(() => cloudvariables.setVariable(name, 'asdf'))
+                .catch(err => assert(err.message.includes('password')));
+        });
+
+        it('should not delete variables w/ bad password', function() {
+            const name = newVar();
+            return cloudvariables.setVariable(name, 'world', 'password')
+                .then(() => cloudvariables.deleteVariable(name))
+                .catch(err => assert(err.message.includes('password')));
+        });
+    });
+
+    describe('user', function() {
+        beforeEach(function() {
+            cloudvariables.socket.loggedIn = true;
+            cloudvariables.socket.username = 'brian';
+        });
+
+        it('should get/set variables', function() {
+            const name = newVar();
+            return cloudvariables.setUserVariable(name, 'world')
+                .then(() => cloudvariables.getUserVariable(name))
+                .then(result => assert.equal(result, 'world'));
+        });
+
+        it('should delete variables', function() {
+            const name = newVar();
+            return cloudvariables.setUserVariable(name, 'world')
+                .then(() => cloudvariables.deleteUserVariable(name))
+                .then(() => cloudvariables.getUserVariable(name))
+                .catch(err => assert(err.message.includes('not found')));
+        });
+
+        it('should not set other user variables', function() {
+            const name = newVar();
+            return cloudvariables.setUserVariable(name, 'world')
+                .then(() => {
+                    cloudvariables.socket.username = 'hamid';
+                    return cloudvariables.getUserVariable(name);
+                })
+                .catch(err => assert(err.message.includes('not found')));
+        });
+
+        it('should not delete variables w/ bad password', function() {
+            const name = newVar();
+            return cloudvariables.setUserVariable(name, 'world')
+                .then(() => cloudvariables.deleteUserVariable(name))
+                .catch(err => assert(err.message.includes('password')));
+        });
+    });
 });


### PR DESCRIPTION
This pull request adds support for cloud variables in NetsBlox (similar to the existing KeyValueStore). There are two types of variables: public (default) and user (inspired by https://github.com/LLK/scratch-flash/issues/689). 

Public cloud variables can be shared between any two projects. This includes getting, setting, and deleting. Variables can be protected by providing a "password" argument to the service. This will result in the variable being password-protected (reads, writes, and deletion).

User cloud variables are stored for the given user (as the name suggests). 

In our deployment, all variables are subject to deletion after 30 days of inactivity (this is included in the service description).