### PR TITLE
googlemaps cache precision fixes #2036

### DIFF
--- a/src/server/rpc/procedures/google-maps/google-maps.js
+++ b/src/server/rpc/procedures/google-maps/google-maps.js
@@ -63,12 +63,16 @@ GoogleMaps.prototype._pixelsAt = function(lat, lon, map) {
 };
 
 
-GoogleMaps.prototype._getGoogleParams = function(options) {
+// precisionLimit if present would limit the precision of coordinate parameters
+GoogleMaps.prototype._getGoogleParams = function(options, precisionLimit) {
     // Create the params for Google
     var params = [];
     params.push('size=' + options.width + 'x' + options.height);
     params.push('scale=' + options.scale);
-    params.push('center=' + options.center.lat + ',' + options.center.lon);
+    // reduce lat lon precisionLimit to a reasonable value to reduce cache misses
+    let centerLat = precisionLimit ? parseFloat(options.center.lat).toFixed(precisionLimit) : options.center.lat;
+    let centerLon = precisionLimit ? parseFloat(options.center.lon).toFixed(precisionLimit) : options.center.lon;
+    params.push('center=' + centerLat + ',' + centerLon);
     params.push('key=' + key);
     params.push('zoom='+(options.zoom || '12'));
     params.push('maptype='+(options.mapType));

--- a/src/server/rpc/procedures/google-maps/google-maps.js
+++ b/src/server/rpc/procedures/google-maps/google-maps.js
@@ -132,7 +132,10 @@ GoogleMaps.prototype._getMap = function(latitude, longitude, width, height, zoom
     // Check the cache
     this._recordUserMap(this.socket, options).then(() => {
 
-        cache.wrap(url, cacheCallback => {
+        // allow the lookups that are "close" to an already visited location hit the cache
+        const PRECISION = 7; // 6 or 5 is probabbly safe
+        const cacheKey = this._getGoogleParams(options, PRECISION);
+        cache.wrap(cacheKey, cacheCallback => {
             // Get the image -> not in cache!
             trace('request params:', options);
             trace('url is '+url);

--- a/src/server/rpc/procedures/google-maps/google-maps.js
+++ b/src/server/rpc/procedures/google-maps/google-maps.js
@@ -133,7 +133,7 @@ GoogleMaps.prototype._getMap = function(latitude, longitude, width, height, zoom
     this._recordUserMap(this.socket, options).then(() => {
 
         // allow the lookups that are "close" to an already visited location hit the cache
-        const PRECISION = 7; // 6 or 5 is probabbly safe
+        const PRECISION = 7; // 6 or 5 is probably safe
         const cacheKey = this._getGoogleParams(options, PRECISION);
         cache.wrap(cacheKey, cacheCallback => {
             // Get the image -> not in cache!

--- a/test/unit/server/rpc/procedures/google-maps.spec.js
+++ b/test/unit/server/rpc/procedures/google-maps.spec.js
@@ -67,4 +67,34 @@ describe('googlemaps', function() {
 
     });
 
+    describe('getGoogleParams', function() {
+
+        const opts = {
+            center: {
+                lat: 36.2645738345627,
+                lon: -82.54322767345267,
+            },
+            width: (640 / 1),
+            height: (480 / 1),
+            zoom: 15,
+            scale: 1,
+            mapType: 'roadmap'
+        };
+
+        it('should round coordinates properly', function() {
+            let params = googlemaps._rpc._getGoogleParams(opts, 4);
+            let outCoords = params.match(/center=(.*)&key/)[1];
+            const expectedCoords = '36.2646,-82.5432';
+            assert.equal(outCoords, expectedCoords);
+        });
+
+        it('should not round coordinates', function() {
+            let params = googlemaps._rpc._getGoogleParams(opts);
+            let outCoords = params.match(/center=(.*)&key/)[1];
+            const expectedCoords = '36.2645738345627,-82.54322767345268';
+            assert.equal(outCoords, expectedCoords);
+        });
+
+    });
+
 });

--- a/test/unit/server/rpc/procedures/google-maps.spec.js
+++ b/test/unit/server/rpc/procedures/google-maps.spec.js
@@ -1,20 +1,20 @@
-describe('staticmap', function() {
+describe('googlemaps', function() {
     const utils = require('../../../../assets/utils');
-    var StaticMap = utils.reqSrc('rpc/procedures/google-maps/google-maps'),
+    var Googlemaps = utils.reqSrc('rpc/procedures/google-maps/google-maps'),
         RPCMock = require('../../../../assets/mock-rpc'),
         assert = require('assert'),
-        staticmap = new RPCMock(StaticMap);
+        googlemaps = new RPCMock(Googlemaps);
 
     before(function(done) {
         utils.connect()
             .then(() => {
-                staticmap = new RPCMock(StaticMap);
+                googlemaps = new RPCMock(Googlemaps);
                 done();
             });
     });
 
     describe('interfaces', function() {
-        utils.verifyRPCInterfaces(staticmap, [
+        utils.verifyRPCInterfaces(googlemaps, [
             ['getMap', ['latitude', 'longitude', 'width', 'height', 'zoom']],
             ['getSatelliteMap', ['latitude', 'longitude', 'width', 'height', 'zoom']],
             ['getTerrainMap', ['latitude', 'longitude', 'width', 'height', 'zoom']],
@@ -34,11 +34,11 @@ describe('staticmap', function() {
 
     describe('getDistance', function() {
         it('should calculate distance in meters (string input)', function(){
-            let distance = staticmap.getDistance('36', '-86', '36', '-87');
+            let distance = googlemaps.getDistance('36', '-86', '36', '-87');
             assert.deepEqual(distance, 90163);
         });
         it('should calculate distance in meters (integer input)', function(){
-            let distance = staticmap.getDistance(36, -86, 36, -87);
+            let distance = googlemaps.getDistance(36, -86, 36, -87);
             assert.deepEqual(distance, 90163);
         });
     });
@@ -58,10 +58,10 @@ describe('staticmap', function() {
         };
 
         it('should handle wraparound at map boundaries', function(){
-            let coords = staticmap._rpc._coordsAt(-170, 90, map);
+            let coords = googlemaps._rpc._coordsAt(-170, 90, map);
             assert(coords.lon > -180 && coords.lon < 180);
             map.center.lon = +150;
-            coords = staticmap._rpc._coordsAt(170, 90, map);
+            coords = googlemaps._rpc._coordsAt(170, 90, map);
             assert(coords.lon > -180 && coords.lon < 180);
         });
 


### PR DESCRIPTION
support for limiting cache buster precision. 
sets the precision limit to 7 meaning lat or lon of `ab.1234567WX == ab.1234567YZ`