### PR TITLE
linting support for Ecmascript 2017 Fixes #2174

### DIFF
--- a/.eslintrc.yml
+++ b/.eslintrc.yml
@@ -4,6 +4,8 @@ env:
   mocha: true
   es6: true
 extends: 'eslint:recommended'
+parserOptions:
+  ecmaVersion: 8 # 2017
 rules:
   indent:
     - 2


### PR DESCRIPTION
updates Eslint to support es8 syntax. We still should keep the shared code with snap (client-side) code restricted to es5