### PR TITLE
Waterwatch's stop RPC replies with a promise Fixes #2184

### DIFF
--- a/src/server/rpc/procedures/utils/api-consumer.js
+++ b/src/server/rpc/procedures/utils/api-consumer.js
@@ -291,7 +291,8 @@ class ApiConsumer {
             delete this._remainingMsgs[this.socket.uuid];
             this._logger.trace('stopped sending messages for uuid:',this.socket.uuid, this.socket.role);
         }else {
-            return 'there are no messages in the queue to stop.';
+            this.response.status(304).send('stopping sending of the remaining ' + 0 + 'msgs');
+            this._logger.trace('there are no messages in the queue to stop.');
         }
     }
 }

--- a/src/server/rpc/procedures/utils/api-consumer.js
+++ b/src/server/rpc/procedures/utils/api-consumer.js
@@ -294,6 +294,7 @@ class ApiConsumer {
             this.response.status(304).send('stopping sending of the remaining ' + 0 + 'msgs');
             this._logger.trace('there are no messages in the queue to stop.');
         }
+        return null; // allows the caller to just return this function
     }
 }
 

--- a/src/server/rpc/procedures/utils/api-consumer.js
+++ b/src/server/rpc/procedures/utils/api-consumer.js
@@ -286,15 +286,16 @@ class ApiConsumer {
     }
 
     _stopMsgs(){
+        let msgCount;
         if (this._remainingMsgs[this.socket.uuid]) {
-            this.response.status(200).send('stopping sending of the remaining ' + this._remainingMsgs[this.socket.uuid].length + 'msgs');
+            msgCount = this._remainingMsgs[this.socket.uuid].length;
             delete this._remainingMsgs[this.socket.uuid];
             this._logger.trace('stopped sending messages for uuid:',this.socket.uuid, this.socket.role);
         }else {
-            this.response.status(304).send('stopping sending of the remaining ' + 0 + 'msgs');
+            msgCount = 0;
             this._logger.trace('there are no messages in the queue to stop.');
         }
-        return null; // allows the caller to just return this function
+        return msgCount;
     }
 }
 

--- a/src/server/rpc/procedures/water-watch/water-watch.js
+++ b/src/server/rpc/procedures/water-watch/water-watch.js
@@ -96,8 +96,7 @@ waterwatch.waterTemp = function (minLatitude, maxLatitude, minLongitude, maxLong
 };
 
 waterwatch.stop = function(){
-    this._stopMsgs();
-    return Promise.resolve();
+    return this._stopMsgs();
 };
 
 module.exports = waterwatch;

--- a/src/server/rpc/procedures/water-watch/water-watch.js
+++ b/src/server/rpc/procedures/water-watch/water-watch.js
@@ -96,7 +96,6 @@ waterwatch.waterTemp = function (minLatitude, maxLatitude, minLongitude, maxLong
 };
 
 /**
- * Ask the server to stop sending messages.
  * @returns {Number} Number of messages stopped.
  */
 waterwatch.stop = function(){

--- a/src/server/rpc/procedures/water-watch/water-watch.js
+++ b/src/server/rpc/procedures/water-watch/water-watch.js
@@ -97,7 +97,7 @@ waterwatch.waterTemp = function (minLatitude, maxLatitude, minLongitude, maxLong
 
 waterwatch.stop = function(){
     this._stopMsgs();
-    return null;
+    return Promise.resolve();
 };
 
 module.exports = waterwatch;

--- a/src/server/rpc/procedures/water-watch/water-watch.js
+++ b/src/server/rpc/procedures/water-watch/water-watch.js
@@ -95,6 +95,10 @@ waterwatch.waterTemp = function (minLatitude, maxLatitude, minLongitude, maxLong
     return this._sendMsgs(queryOptions, parser, 'waterTemp');
 };
 
+/**
+ * Ask the server to stop sending messages.
+ * @returns {Number} Number of messages stopped.
+ */
 waterwatch.stop = function(){
     return this._stopMsgs();
 };


### PR DESCRIPTION
right now waterwatche's stop RPC returns null therefore the HTTP request to its corresponding endpoint hangs. This PR changes the RPC to return a promise which is then handled by RPC manager.