### PR TITLE
disallow easy robot id matching #2190

### DIFF
--- a/src/server/rpc/procedures/roboscape/roboscape.js
+++ b/src/server/rpc/procedures/roboscape/roboscape.js
@@ -578,8 +578,10 @@ RoboScape.prototype._addRobot = function (mac_addr, ip4_addr, ip4_port) {
     return robot;
 };
 
+// fails silently if it can't get the robot
 RoboScape.prototype._getRobot = function (robot) {
     robot = '' + robot;
+    if( robot.length < 4) return false;
     if (robot.length === 6) {
         return RoboScape.prototype._robots[robot];
     }

--- a/src/server/rpc/procedures/roboscape/roboscape.js
+++ b/src/server/rpc/procedures/roboscape/roboscape.js
@@ -578,10 +578,9 @@ RoboScape.prototype._addRobot = function (mac_addr, ip4_addr, ip4_port) {
     return robot;
 };
 
-// fails silently if it can't get the robot
 RoboScape.prototype._getRobot = function (robot) {
     robot = '' + robot;
-    if( robot.length < 4) return false;
+    if(robot.length < 4) return undefined;
     if (robot.length === 6) {
         return RoboScape.prototype._robots[robot];
     }


### PR DESCRIPTION
since many of the RPCs in this service return false if they fail it might be good to also return false in this case too. We could on other hand return a message or maybe utilize the error block?!