### PR TITLE
prepration for routes tests fixes #2229

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -389,6 +389,7 @@
       "version": "0.18.0",
       "resolved": "https://registry.npmjs.org/axios/-/axios-0.18.0.tgz",
       "integrity": "sha1-MtU+SFHv3AoRmTts0AB4nXDAUQI=",
+      "dev": true,
       "requires": {
         "follow-redirects": "^1.3.0",
         "is-buffer": "^1.1.5"
@@ -2511,6 +2512,7 @@
       "version": "1.5.7",
       "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.5.7.tgz",
       "integrity": "sha512-NONJVIFiX7Z8k2WxfqBjtwqMifx7X42ORLFrOZ2LTKGj71G3C0kfdyTqGqr8fx5zSX6Foo/D95dgGWbPUiwnew==",
+      "dev": true,
       "requires": {
         "debug": "^3.1.0"
       },
@@ -2519,6 +2521,7 @@
           "version": "3.1.0",
           "resolved": "https://registry.npmjs.org/debug/-/debug-3.1.0.tgz",
           "integrity": "sha512-OX8XqP7/1a9cqkxYw2yXss15f26NKWBpDXQd0/uK/KPqdQhxbPa994hnzjcE2VqQpDslf55723cKPUOGSmMY3g==",
+          "dev": true,
           "requires": {
             "ms": "2.0.0"
           }
@@ -8746,7 +8749,8 @@
     "xmlhttprequest": {
       "version": "1.8.0",
       "resolved": "https://registry.npmjs.org/xmlhttprequest/-/xmlhttprequest-1.8.0.tgz",
-      "integrity": "sha1-Z/4HXFwk/vOfnWX197f+dRcZaPw="
+      "integrity": "sha1-Z/4HXFwk/vOfnWX197f+dRcZaPw=",
+      "dev": true
     },
     "xmlhttprequest-ssl": {
       "version": "1.5.1",

--- a/package-lock.json
+++ b/package-lock.json
@@ -385,6 +385,15 @@
       "resolved": "https://registry.npmjs.org/aws4/-/aws4-1.6.0.tgz",
       "integrity": "sha1-g+9cqGCysy5KDe7e6MdxudtXRx4="
     },
+    "axios": {
+      "version": "0.18.0",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-0.18.0.tgz",
+      "integrity": "sha1-MtU+SFHv3AoRmTts0AB4nXDAUQI=",
+      "requires": {
+        "follow-redirects": "^1.3.0",
+        "is-buffer": "^1.1.5"
+      }
+    },
     "backo2": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/backo2/-/backo2-1.0.2.tgz",
@@ -2495,6 +2504,24 @@
           "version": "1.4.0",
           "resolved": "https://registry.npmjs.org/statuses/-/statuses-1.4.0.tgz",
           "integrity": "sha512-zhSCtt8v2NDrRlPQpCNtw/heZLtfUDqxBM1udqikb/Hbk52LK4nQSwr10u77iopCW5LsyHpuXS0GnEc48mLeew=="
+        }
+      }
+    },
+    "follow-redirects": {
+      "version": "1.5.7",
+      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.5.7.tgz",
+      "integrity": "sha512-NONJVIFiX7Z8k2WxfqBjtwqMifx7X42ORLFrOZ2LTKGj71G3C0kfdyTqGqr8fx5zSX6Foo/D95dgGWbPUiwnew==",
+      "requires": {
+        "debug": "^3.1.0"
+      },
+      "dependencies": {
+        "debug": {
+          "version": "3.1.0",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-3.1.0.tgz",
+          "integrity": "sha512-OX8XqP7/1a9cqkxYw2yXss15f26NKWBpDXQd0/uK/KPqdQhxbPa994hnzjcE2VqQpDslf55723cKPUOGSmMY3g==",
+          "requires": {
+            "ms": "2.0.0"
+          }
         }
       }
     },
@@ -8715,6 +8742,11 @@
       "requires": {
         "lodash": "^4.0.0"
       }
+    },
+    "xmlhttprequest": {
+      "version": "1.8.0",
+      "resolved": "https://registry.npmjs.org/xmlhttprequest/-/xmlhttprequest-1.8.0.tgz",
+      "integrity": "sha1-Z/4HXFwk/vOfnWX197f+dRcZaPw="
     },
     "xmlhttprequest-ssl": {
       "version": "1.5.1",

--- a/package.json
+++ b/package.json
@@ -31,7 +31,6 @@
   "dependencies": {
     "async": "^2.0.0-rc.2",
     "aws-sdk": "^2.203.0",
-    "axios": "^0.18.0",
     "body-parser": "^1.12.4",
     "cache-manager": "^2.0.0",
     "cache-manager-fs": "^1.0.6",
@@ -78,15 +77,16 @@
     "urlencode": "^1.1.0",
     "vantage": "^1.5.1",
     "vantage-repl": "^1.1.4",
-    "ws": "^5.1.0",
-    "xmlhttprequest": "^1.8.0"
+    "ws": "^5.1.0"
   },
   "devDependencies": {
+    "axios": "^0.18.0",
     "expect": "^1.6.0",
     "istanbul": "^0.4.5",
     "mocha": "^3.2.0",
     "nodemon": "^1.3.7",
     "supertest": "^3.0.0",
-    "uglify-js": "^3.3.17"
+    "uglify-js": "^3.3.17",
+    "xmlhttprequest": "^1.8.0"
   }
 }

--- a/package.json
+++ b/package.json
@@ -31,6 +31,7 @@
   "dependencies": {
     "async": "^2.0.0-rc.2",
     "aws-sdk": "^2.203.0",
+    "axios": "^0.18.0",
     "body-parser": "^1.12.4",
     "cache-manager": "^2.0.0",
     "cache-manager-fs": "^1.0.6",
@@ -77,7 +78,8 @@
     "urlencode": "^1.1.0",
     "vantage": "^1.5.1",
     "vantage-repl": "^1.1.4",
-    "ws": "^5.1.0"
+    "ws": "^5.1.0",
+    "xmlhttprequest": "^1.8.0"
   },
   "devDependencies": {
     "expect": "^1.6.0",

--- a/test/features/routes/groups.spec.js
+++ b/test/features/routes/groups.spec.js
@@ -1,0 +1,37 @@
+const axios = require('axios'),
+    AuthHandler = require('../../utils/auth'),
+    assert = require('assert'),
+    utils = require('../../assets/utils');
+
+let server, port = 8440;
+let options = {
+    port,
+    vantage: false
+};
+
+const SERVER_ADDRESS = `http://localhost:${port}`;
+const authenticator = new AuthHandler(SERVER_ADDRESS);
+let loginCookie;
+
+describe.skip('groups routes', () => {
+    before(function(done) {
+        utils.reset().then(() => {
+            const Server = require('../../../src/server/server');
+            server = new Server(options);
+            server.start(async () => {
+                let res = await authenticator.login('hamid', 'monkey123');
+                loginCookie = res.getResponseHeader('Set-Cookie')[0];
+                axios.defaults.headers.common['Cookie'] = loginCookie;
+                done();
+            });
+        });
+    });
+
+    it('should do stuff', async () => {
+        assert(true);
+    });
+
+    after(function(done) {
+        server.stop(done);
+    });
+});

--- a/test/utils/auth.js
+++ b/test/utils/auth.js
@@ -1,0 +1,97 @@
+const XMLHttpRequest = require('xmlhttprequest').XMLHttpRequest,
+    hex_sha512 =  require('./sha512').hex_sha512;
+'use strict';
+/* global hex_sha512 */
+
+/* NetsBlox client authentication library
+ * Find the latest version in the github repo:
+ * https://github.com/NetsBlox/client-auth
+ */
+
+class AuthHandler {
+    constructor(serverUrl) {
+        if (serverUrl.endsWith('/')) serverUrl = serverUrl.substr(0, serverUrl.length-1);
+        this.serverUrl = serverUrl;
+    }
+
+    _requestPromise(request, data) {
+        return new Promise((resolve, reject) => {
+            // stringifying undefined => undefined
+            if (data) {
+                request.setRequestHeader(
+                    'Content-Type',
+                    'application/json; charset=utf-8'
+                );
+            }
+            request.send(JSON.stringify(data));
+            request.onreadystatechange = function () {
+                if (request.readyState === 4) {
+                    if (request.status >= 200 && request.status < 300) {
+                        resolve(request);
+                    } else {
+                        let err = new Error(request.statusText || 'Unsuccessful Xhr response');
+                        err.request = request;
+                        reject(err);
+                    }
+                }
+            };
+        });
+    }
+
+    login(username, password) {
+        const request = new XMLHttpRequest();
+        request.open('POST', `${this.serverUrl}/api`, true);
+        request.withCredentials = true;
+        const data = {
+            __u: username,
+            __h: hex_sha512(password)
+        };
+        return this._requestPromise(request, data);
+    }
+
+    logout() {
+        const request = new XMLHttpRequest();
+        request.open('POST', `${this.serverUrl}/api/logout`, true);
+        request.withCredentials = true;
+        return this._requestPromise(request);
+    }
+
+    register(username, email, password) {
+        const request = new XMLHttpRequest();
+        request.open('POST', `${this.serverUrl}/api/SignUp`, true);
+        request.withCredentials = true;
+        const data = {
+            Username: username,
+            Password: hex_sha512(password),
+            Email: email
+        };
+        return this._requestPromise(request, data);
+    }
+
+    checkLogin() {
+        const request = new XMLHttpRequest();
+        request.open('POST', `${this.serverUrl}/api`, true);
+        request.withCredentials = true;
+        return this._requestPromise(request);
+    }
+
+    // gets user info: username, email
+    getProfile() {
+        const request = new XMLHttpRequest();
+        request.open('POST', `${this.serverUrl}/api`, true);
+        request.withCredentials = true;
+        const data = {
+            api: false,
+            return_user: true,
+            silent: true
+        };
+        return this._requestPromise(request, data)
+            .then(res => {
+                if (!res.responseText) throw new Error('Access denied. You are not logged in.');
+                let user = JSON.parse(res.responseText);
+                return user;
+            });
+    }
+}
+
+module.exports = AuthHandler;

--- a/test/utils/sha512.js
+++ b/test/utils/sha512.js
@@ -1,3 +1,4 @@
+/* eslint-disable */
 /*
 
 	sha512.js
@@ -16,7 +17,7 @@
 
 */
 
-var hex_sha512 = (function (hex_sha512) {
+(function (global) {
 
     var hexcase = 0;
 
@@ -342,6 +343,6 @@ var hex_sha512 = (function (hex_sha512) {
        dst.h = (w2 & 0xffff) | (w3 << 16);
     }
 
-    return hex_sha512;
+    return global.hex_sha512 = hex_sha512;
 
-})({});
+})(this);


### PR DESCRIPTION
- adds clientside authenticator library keeping it as close to the browser env as possible using `xmlhttprequest` package
- modifies sha512 to be importable in node
- sets up the directory for route tests

required by #1699 