### PR TITLE
fixed var name collision bug fixes #2250

### DIFF
--- a/src/server/rpc/procedures/roboscape/roboscape.js
+++ b/src/server/rpc/procedures/roboscape/roboscape.js
@@ -337,11 +337,11 @@ Robot.prototype.sendToClient = function (msgType, content, fields) {
                     text += ' ' + content[fields[i]];
                 }
 
-                const content = {
+                const encryptedContent = {
                     robot: myself.mac_addr,
                     message: myself.encrypt(text.trim())
                 };
-                socket.sendMessage('robot message', content);
+                socket.sendMessage('robot message', encryptedContent);
             }
         } else {
             logger.log('socket not found for ' + uuid);


### PR DESCRIPTION
- renamed `content` to avoid name collision and losing function argument