### PR TITLE
Translation RPC #2252

### DIFF
--- a/src/server/rpc/procedures/azure-translation/azure-translation.js
+++ b/src/server/rpc/procedures/azure-translation/azure-translation.js
@@ -7,7 +7,7 @@
  */
 
 const ApiConsumer = require('../utils/api-consumer');
-const TranslationConsumer = new ApiConsumer('azure-translation', 'https://api.cognitive.microsofttranslator.com/translate?api-version=3.0',{cache: {ttl: 15 * 60}});
+const TranslationConsumer = new ApiConsumer('azure-translation', 'https://api.cognitive.microsofttranslator.com/',{cache: {ttl: 15 * 60}});
 const key = process.env.AZURE_TRANSLATION_KEY;
 
 /**
@@ -28,12 +28,44 @@ TranslationConsumer._get_guid = function () {
 TranslationConsumer.toEnglish = function(text) {
     let body = [{'Text' : text}];
     let guid = this._get_guid();
-    return this._sendAnswer({queryString: `&to=en&h=${guid}`,
+    return this._sendAnswer({queryString: `translate?api-version=3.0&to=en&h=${guid}`,
         method: 'POST',
         headers: { 'Content-Type' : 'application/json',
                     'Ocp-Apim-Subscription-Key' : key,
                     'X-ClientTraceId' : guid},
         body: body}, '.translations .text[0]')
+        .catch(err => {
+            throw err;
+        });
+};
+
+/**
+ * Attempt to detect language of input text
+ * @param {String} text Text in an unknown language
+ * @returns {String} Abbreviation for name of language detected in text
+ */
+TranslationConsumer.detectLanguage = function(text) {
+    let body = [{'Text' : text}];
+    let guid = this._get_guid();
+    return this._sendAnswer({queryString: `detect?api-version=3.0&h=${guid}`,
+        method: 'POST',
+        headers: { 'Content-Type' : 'application/json',
+                    'Ocp-Apim-Subscription-Key' : key,
+                    'X-ClientTraceId' : guid},
+        body: body}, '.language[0]')
+        .catch(err => {
+            throw err;
+        });
+};
+
+/**
+ * Attempt to detect language of input text
+ * @returns {Array} List of languages supported by the translator
+ */
+TranslationConsumer.getSupportedLanguages = function() {
+    return this._sendAnswer({queryString: `languages?api-version=3.0&scope=translation`,
+        headers: { 'Content-Type' : 'application/json',
+                    'Ocp-Apim-Subscription-Key' : key}}, '.translation')
         .catch(err => {
             throw err;
         });

--- a/src/server/rpc/procedures/azure-translation/azure-translation.js
+++ b/src/server/rpc/procedures/azure-translation/azure-translation.js
@@ -1,0 +1,53 @@
+/**
+ * Uses Microsoft's Azure Cognitive Services API to translate text.
+ * For more information, check out https://azure.microsoft.com/en-us/pricing/details/cognitive-services/translator-text-api/.
+ *
+ * Terms of use: https://www.microsoft.com/en-us/servicesagreement
+ * @service
+ */
+
+const ApiConsumer = require('../utils/api-consumer');
+const TranslationConsumer = new ApiConsumer('azure-translation', 'https://api.cognitive.microsofttranslator.com/translate?api-version=3.0',{cache: {ttl: 15 * 60}});
+const key = process.env.AZURE_TRANSLATION_KEY;
+
+/**
+ * Generates a GUID-like string
+ */
+TranslationConsumer._get_guid = function () {
+    return 'xxxxxxxx-xxxx-4xxx-yxxx-xxxxxxxxxxxx'.replace(/[xy]/g, function(c) {
+        var r = Math.random() * 16 | 0, v = c == 'x' ? r : (r & 0x3 | 0x8);
+        return v.toString(16);
+    });
+};
+
+/**
+ * Translate text to English
+ * @param {String} text Text in another language
+ * @returns {String} Text translated to English
+ */
+TranslationConsumer.toEnglish = function(text) {
+    let body = [{'Text' : text}];
+    let guid = this._get_guid();
+    return this._sendAnswer({queryString: `&to=en&h=${guid}`,
+        method: 'POST',
+        headers: { 'Content-Type' : 'application/json',
+                    'Ocp-Apim-Subscription-Key' : key,
+                    'X-ClientTraceId' : guid},
+        body: body}, '.translations .text[0]')
+        .catch(err => {
+            throw err;
+        });
+};
+
+TranslationConsumer.isSupported = () => {
+    if(!key){
+        /* eslint-disable no-console*/
+        console.error('AZURE_TRANSLATION_KEY is missing.');
+        /* eslint-enable no-console*/
+    }
+    return !!key;
+};
+
+TranslationConsumer.serviceName = 'Translation';
+
+module.exports = TranslationConsumer;

--- a/src/server/rpc/procedures/azure-translation/azure-translation.js
+++ b/src/server/rpc/procedures/azure-translation/azure-translation.js
@@ -21,14 +21,23 @@ TranslationConsumer._get_guid = function () {
 };
 
 /**
- * Translate text to English
+ * Translate text between languages
  * @param {String} text Text in another language
+ * @param {String=} from Text in another language
+ * @param {String} to Text in another language
  * @returns {String} Text translated to English
  */
-TranslationConsumer.toEnglish = function(text) {
+TranslationConsumer.translate = function(text, from, to) {
     let body = [{'Text' : text}];
     let guid = this._get_guid();
-    return this._sendAnswer({queryString: `translate?api-version=3.0&to=en&h=${guid}`,
+    let query = `translate?api-version=3.0&to=${to}&h=${guid}`;
+
+    if(from)
+    {
+        query = query + `&from=${from}`;
+    }
+
+    return this._sendAnswer({queryString: query,
         method: 'POST',
         headers: { 'Content-Type' : 'application/json',
                     'Ocp-Apim-Subscription-Key' : key,
@@ -37,6 +46,15 @@ TranslationConsumer.toEnglish = function(text) {
         .catch(err => {
             throw err;
         });
+};
+
+/**
+ * Translate text to English
+ * @param {String} text Text in another language
+ * @returns {String} Text translated to English
+ */
+TranslationConsumer.toEnglish = function(text) {
+    return this.translate(text, null, "en");
 };
 
 /**
@@ -70,6 +88,8 @@ TranslationConsumer.getSupportedLanguages = function() {
             throw err;
         });
 };
+
+
 
 TranslationConsumer.isSupported = () => {
     if(!key){

--- a/src/server/rpc/procedures/azure-translation/azure-translation.js
+++ b/src/server/rpc/procedures/azure-translation/azure-translation.js
@@ -23,9 +23,9 @@ TranslationConsumer._get_guid = function () {
 /**
  * Translate text between languages
  * @param {String} text Text in another language
- * @param {String=} from Text in another language
- * @param {String} to Text in another language
- * @returns {String} Text translated to English
+ * @param {String=} from Language to translate from (auto-detects if not specified)
+ * @param {String} to Language to translate to
+ * @returns {String} Text translated to requested language
  */
 TranslationConsumer.translate = function(text, from, to) {
     let body = [{'Text' : text}];

--- a/test/unit/server/rpc/procedures/azure-translation.spec.js
+++ b/test/unit/server/rpc/procedures/azure-translation.spec.js
@@ -1,10 +1,12 @@
 describe('azure-translation', function() {
     const utils = require('../../../../assets/utils');
-    var StockService = utils.reqSrc('rpc/procedures/azure-translation/azure-translation'),
+    var TranslationService = utils.reqSrc('rpc/procedures/azure-translation/azure-translation'),
         RPCMock = require('../../../../assets/mock-rpc'),
-        stocks = new RPCMock(StockService);
+        translation = new RPCMock(TranslationService);
 
-    utils.verifyRPCInterfaces(stocks, [
+    utils.verifyRPCInterfaces(translation, [
         ['toEnglish', ['text']],
+        ['detectLanguage', ['text']],
+        ['getSupportedLanguages', []],
     ]);
 });

--- a/test/unit/server/rpc/procedures/azure-translation.spec.js
+++ b/test/unit/server/rpc/procedures/azure-translation.spec.js
@@ -1,0 +1,10 @@
+describe('azure-translation', function() {
+    const utils = require('../../../../assets/utils');
+    var StockService = utils.reqSrc('rpc/procedures/azure-translation/azure-translation'),
+        RPCMock = require('../../../../assets/mock-rpc'),
+        stocks = new RPCMock(StockService);
+
+    utils.verifyRPCInterfaces(stocks, [
+        ['toEnglish', ['text']],
+    ]);
+});

--- a/test/unit/server/rpc/procedures/azure-translation.spec.js
+++ b/test/unit/server/rpc/procedures/azure-translation.spec.js
@@ -5,6 +5,7 @@ describe('azure-translation', function() {
         translation = new RPCMock(TranslationService);
 
     utils.verifyRPCInterfaces(translation, [
+        ['translate', ['text', 'from', 'to']],
         ['toEnglish', ['text']],
         ['detectLanguage', ['text']],
         ['getSupportedLanguages', []],


### PR DESCRIPTION
This adds an RPC that uses Microsoft's translation API.

The only change I'd like to make is to come up with a good string hashing method that produces a GUID-like output so we can have better caching for repeated requests.

The toEnglish call was specifically requested for this.

