### PR TITLE
snapstructure disable filtering of falsy values in arrays Fixes #2258

### DIFF
--- a/src/server/rpc/procedures/utils/index.js
+++ b/src/server/rpc/procedures/utils/index.js
@@ -46,7 +46,6 @@ const jsonToSnapList = inputJson => {
 
     let keyVals = [];
     if (Array.isArray(inputJson)) {
-        inputJson = inputJson.filter(item => item);
         for (let i = 0; i < inputJson.length; i++) {
             keyVals.push(jsonToSnapList(inputJson[i]));
         }

--- a/test/unit/server/rpc/procedures/utils/index.js
+++ b/test/unit/server/rpc/procedures/utils/index.js
@@ -46,12 +46,12 @@ describe('snap structure creation', function() {
         assert.deepEqual(utils.jsonToSnapList(stringJson)[2][1], 'foo');
     });
 
-    it('should remove null items from the array', function(){
-        let arrayWithNull = multipleData;
+    it('should not remove null or falsy items from the array', function(){
+        let arrayWithNull = [...multipleData];
         arrayWithNull.push(null);
         const nullArray = [null,null,false,undefined];
-        assert.equal(utils.jsonToSnapList(arrayWithNull).length, 3);
-        assert.deepEqual(utils.jsonToSnapList(nullArray),[]);
+        assert.equal(utils.jsonToSnapList(arrayWithNull).length, 4);
+        assert.deepEqual(utils.jsonToSnapList(nullArray).length, 4);
     });
 
     it('should convert date objects to GMT datestring', function(){


### PR DESCRIPTION
through a series of pull requests, this has become an issue mainly with table display form of the charting service's default options. More info available in the attached issue