### PR TITLE
Added custom cache key for Translation RPC and increased cache time Fix #2256 

### DIFF
--- a/src/server/rpc/procedures/azure-translation/azure-translation.js
+++ b/src/server/rpc/procedures/azure-translation/azure-translation.js
@@ -31,7 +31,7 @@ TranslationConsumer._getCacheKey = function(queryOptions){
     parameters.push(fullUrl);
     if (queryOptions.body) parameters.push(JSON.stringify(queryOptions.body));
     return parameters.join(' ');
-}
+};
 
 /**
  * Translate text between languages
@@ -79,7 +79,7 @@ TranslationConsumer.toEnglish = function(text) {
 TranslationConsumer.detectLanguage = function(text) {
     let body = [{'Text' : text}];
     let guid = this._get_guid();
-    return this._sendAnswer({queryString: `detect?api-version=3.0`,
+    return this._sendAnswer({queryString: 'detect?api-version=3.0',
         method: 'POST',
         headers: {
             'Content-Type' : 'application/json',

--- a/src/server/rpc/procedures/azure-translation/azure-translation.js
+++ b/src/server/rpc/procedures/azure-translation/azure-translation.js
@@ -21,19 +21,6 @@ TranslationConsumer._get_guid = function () {
 };
 
 /**
- * Customized cache key to allow translated strings to be cached even though the URL may be identical
- * @param {Object} queryOptions 
- */
-TranslationConsumer._getCacheKey = function(queryOptions){
-    let parameters = [];
-    parameters.push(queryOptions.method || 'GET');
-    let fullUrl = (queryOptions.baseUrl || this._baseUrl) + queryOptions.queryString;
-    parameters.push(fullUrl);
-    if (queryOptions.body) parameters.push(JSON.stringify(queryOptions.body));
-    return parameters.join(' ');
-};
-
-/**
  * Translate text between languages
  * @param {String} text Text in another language
  * @param {String=} from Language to translate from (auto-detects if not specified)


### PR DESCRIPTION
This improves the caching for the Translation service. Now the cache properly uses the text data to distinguish between requests without needing the GUID to be in the URL.

@hamidzr How long are you thinking it should be held in cache?