### PR TITLE
Change how ApiConsumer determines cache keys

### DIFF
--- a/src/server/rpc/procedures/utils/api-consumer.js
+++ b/src/server/rpc/procedures/utils/api-consumer.js
@@ -91,7 +91,7 @@ class ApiConsumer {
         parameters.push(queryOptions.method || 'GET');
         let fullUrl = (queryOptions.baseUrl || this._baseUrl) + queryOptions.queryString;
         parameters.push(fullUrl);
-        if (queryOptions.body) parameters.push(queryOptions.body);
+        if (queryOptions.body) parameters.push(JSON.stringify(queryOptions.body));
         return parameters.join(' ');
     }
 

--- a/src/server/rpc/procedures/utils/api-consumer.js
+++ b/src/server/rpc/procedures/utils/api-consumer.js
@@ -91,6 +91,9 @@ class ApiConsumer {
         parameters.push(queryOptions.method || 'GET');
         let fullUrl = (queryOptions.baseUrl || this._baseUrl) + queryOptions.queryString;
         parameters.push(fullUrl);
+
+        // NOTE: It is possible that an RPC will be made with a non-text request body, preventing this from generating a cache key. 
+        // Please override this method if you are developing an RPC with a body that will not stringify properly
         if (queryOptions.body) parameters.push(JSON.stringify(queryOptions.body));
         return parameters.join(' ');
     }


### PR DESCRIPTION
Needs testing to make sure nothing is broken, but this is the fix from #2260 put directly into ApiConsumer instead of only the Translation service.