### PR TITLE
support for changing debug's output stream on a per level basis

### DIFF
--- a/src/server/logger.js
+++ b/src/server/logger.js
@@ -3,9 +3,21 @@
 var levels = ['trace', 'info', 'log', 'debug', 'warn', 'error'],
     debug = require('debug');
 
+// set which debug levels to send to stderr, the rest will go to stdout
+const STDERR = ['warn', 'error'];
+
 var Logger = function(name) {
     this._name = name;
-    levels.forEach(lvl => this[lvl] = debug(`${name}:${lvl}`));
+    /* eslint-disable no-console*/
+    levels.forEach(lvl => {
+        this[lvl] = debug(`${name}:${lvl}`);
+        if (STDERR.find(item => item === lvl)) {
+            this[lvl].log = console.error.bind(console);
+        } else { // send to stdout
+            this[lvl].log = console.log.bind(console);
+        }
+    });
+    /* eslint-enable no-console*/
 };
 
 Logger.prototype.fork = function(name) {


### PR DESCRIPTION
only send `warn` and `error` log levels to stderr.