### PR TITLE
use client counter for client logger name  Fixes #2281

### DIFF
--- a/src/server/client.js
+++ b/src/server/client.js
@@ -29,7 +29,7 @@ const NetworkTopology = require('./network-topology');
 class Client {
     constructor (logger, socket) {
         this.id = (++counter);
-        this._logger = logger.fork(this.uuid);
+        this._logger = logger.fork('client-'+this.id);
 
         this.loggedIn = false;
         this.projectId = null;


### PR DESCRIPTION
currently, it uses `this.uuid` which cannot be set at that point. might be able to get the clientId through some other way