### PR TITLE
updated Nasa service Fixes #2301

### DIFF
--- a/src/server/rpc/procedures/nasa/nasa.js
+++ b/src/server/rpc/procedures/nasa/nasa.js
@@ -7,8 +7,7 @@
 
 'use strict';
 
-var request = require('request'),
-    axios = require('axios'),
+var axios = require('axios'),
     KEY = process.env.NASA_KEY,
     APOD_URL = 'https://api.nasa.gov/planetary/apod?api_key=' + KEY,
     MARS_URL = 'http://marsweather.ingenology.com/v1/latest/';
@@ -18,23 +17,18 @@ module.exports = {
     serviceName: 'NASA',
 
     // NASA's 'Astronomy Picture of the Day'
-    apod: function() {
-        var response = this.response,
-            socket = this.socket;
-
-        request(APOD_URL, function(err, res, body) {
-            body = JSON.parse(body);
-            const msgType = 'Astronomy Pic of the Day';
-            const content = {
-                date: body.date,
-                title: body.title,
-                link: body.url,
-                description: body.explanation
-            };
-            socket.sendMessage(msgType, content);
-            return response.json(true);
-        });
-        return null;
+    apod: async function() {
+        var socket = this.socket;
+        let { data: body } = await axios.get(APOD_URL);
+        const msgType = 'Astronomy Pic of the Day';
+        const content = {
+            date: body.date,
+            title: body.title,
+            link: body.url,
+            description: body.explanation
+        };
+        socket.sendMessage(msgType, content);
+        return true;
     },
 
     /**

--- a/src/server/rpc/procedures/nasa/nasa.js
+++ b/src/server/rpc/procedures/nasa/nasa.js
@@ -8,9 +8,22 @@
 'use strict';
 
 var axios = require('axios'),
+    rpcUtils = require('../utils'),
     KEY = process.env.NASA_KEY,
     APOD_URL = 'https://api.nasa.gov/planetary/apod?api_key=' + KEY,
     MARS_URL = 'http://marsweather.ingenology.com/v1/latest/';
+
+
+async function fetchApod() {
+    const { data: body } = await axios.get(APOD_URL);
+    const info = {
+        date: body.date,
+        title: body.title,
+        link: body.url,
+        description: body.explanation
+    };
+    return info;
+}
 
 module.exports = {
 
@@ -19,16 +32,15 @@ module.exports = {
     // NASA's 'Astronomy Picture of the Day'
     apod: async function() {
         var socket = this.socket;
-        let { data: body } = await axios.get(APOD_URL);
         const msgType = 'Astronomy Pic of the Day';
-        const content = {
-            date: body.date,
-            title: body.title,
-            link: body.url,
-            description: body.explanation
-        };
+        const content = await fetchApod();
         socket.sendMessage(msgType, content);
         return true;
+    },
+
+    apodDetails: async function() {
+        const data = await fetchApod();
+        return rpcUtils.jsonToSnapList(data);
     },
 
     /**

--- a/src/server/rpc/procedures/nasa/nasa.js
+++ b/src/server/rpc/procedures/nasa/nasa.js
@@ -8,6 +8,7 @@
 'use strict';
 
 var request = require('request'),
+    axios = require('axios'),
     KEY = process.env.NASA_KEY,
     APOD_URL = 'https://api.nasa.gov/planetary/apod?api_key=' + KEY,
     MARS_URL = 'http://marsweather.ingenology.com/v1/latest/';
@@ -36,45 +37,28 @@ module.exports = {
         return null;
     },
 
-    // NASA's 'Astronomy Picture of the Day' media
-    apodMedia: function() {
-        var response = this.response;
-
-        request(APOD_URL, function(err, res, body) {
-            body = JSON.parse(body);
-            request.get(body.url).pipe(response);
-        });
-        return null;
+    /**
+     * NASA's 'Astronomy Picture of the Day' media
+     * @returns {String}
+     */
+    apodMedia: async function() {
+        let { data: body } = await axios.get(APOD_URL);
+        return body.url;
     },
 
     // Latest Mars data according to MAAS
-    marsHighTemp: function() {
-        var response = this.response;
-
-        request(MARS_URL, function(err, res, body) {
-            body = JSON.parse(body);
-            return response.json(body.report.max_temp_fahrenheit);
-        });
-        return null;
+    marsHighTemp: async function() {
+        let { data: body } = await axios.get(MARS_URL);
+        return body.report.max_temp_fahrenheit;
     },
 
-    marsLowTemp: function() {
-        var response = this.response;
-
-        request(MARS_URL, function(err, res, body) {
-            body = JSON.parse(body);
-            return response.json(body.report.min_temp_fahrenheit);
-        });
-        return null;
+    marsLowTemp: async function() {
+        let { data: body } = await axios.get(MARS_URL);
+        return body.report.min_temp_fahrenheit;
     },
 
-    marsWeather: function() {
-        var response = this.response;
-
-        request(MARS_URL, function(err, res, body) {
-            body = JSON.parse(body);
-            return response.json(body.report.atmo_opacity);
-        });
-        return null;
+    marsWeather: async function() {
+        let { data: body } = await axios.get(MARS_URL);
+        return body.report.atmo_opacity;
     }
 };


### PR DESCRIPTION
refactored NASA service to use promises to utilize existing error handling. if the mars service provider doesn't come back online soon we might have to find a substitute or remove that part of the service.

also adds a new rpc: `apodDetails`