### PR TITLE
client-test port number read from env variable

### DIFF
--- a/bin/test-client.sh
+++ b/bin/test-client.sh
@@ -2,10 +2,13 @@
 
 # runs the client tests in a headless chrome
 
+[ -z $PORT ] && port=8080 || port=$PORT
+# WARN if running multilple instances, VANTAGE_PORTs might collide
+
 # check if server is currently running: get the pid
 function serverPid()
 {
-  local pid=$(netstat -nltp 2>/dev/null | grep 8080 | head -n 1 | grep -Eo '[0-9]+/node' | cut -d '/' -f 1)
+  local pid=$(netstat -nltp 2>/dev/null | grep $port | head -n 1 | grep -Eo '[0-9]+/node' | cut -d '/' -f 1)
   echo $pid
 }
 
@@ -20,12 +23,12 @@ if [ -z $initial_pid ]; then
     echo waiting for the server to startup..
     sleep 0.5
   done
-  npx mocha-chrome http://localhost:8080/test --chrome-flags '["--no-sandbox"]'
+  npx mocha-chrome http://localhost:$port/test --chrome-flags '["--no-sandbox"]'
   exit_code=$?
   kill %1 # shutdown netsblox server (job id 1)
 else
   echo "server is already up with pid '$initial_pid'"
-  npx mocha-chrome http://localhost:8080/test --chrome-flags '["--no-sandbox"]'
+  npx mocha-chrome http://localhost:$port/test --chrome-flags '["--no-sandbox"]'
   exit_code=$?
 fi
 exit $exit_code


### PR DESCRIPTION
the test script reads the port from the env variables and defaults to 8080