### PR TITLE
openstreetmap metadata rpcs fixes #2332

### DIFF
--- a/src/server/rpc/procedures/google-streetview/google-streetview.js
+++ b/src/server/rpc/procedures/google-streetview/google-streetview.js
@@ -10,7 +10,7 @@
 var key = process.env.GOOGLE_MAPS_KEY;
 
 const ApiConsumer = require('../utils/api-consumer');
-const GoogleStreetView = new ApiConsumer('google-streetview', 'https://maps.googleapis.com/maps/api/streetview?',{cache: {ttl: 7*24*60*60}});
+const GoogleStreetView = new ApiConsumer('google-streetview', 'https://maps.googleapis.com/maps/api/streetview',{cache: {ttl: 7*24*60*60}});
 
 GoogleStreetView.isSupported = () => {
     if(!key){
@@ -33,7 +33,7 @@ GoogleStreetView.isSupported = () => {
  * @returns {Image} Image of requested location with specified size and orientation
  */
 GoogleStreetView.getViewFromLatLong = function(latitude, longitude, width, height, fieldofview, heading, pitch) {
-    return this._sendImage({queryString: `size=${width}x${height}&location=${latitude},${longitude}&fov=${fieldofview}&heading=${heading}&pitch=${pitch}&key=${key}`, method: 'GET'});
+    return this._sendImage({queryString: `?size=${width}x${height}&location=${latitude},${longitude}&fov=${fieldofview}&heading=${heading}&pitch=${pitch}&key=${key}`, method: 'GET'});
 };
 
 /**
@@ -47,7 +47,7 @@ GoogleStreetView.getViewFromLatLong = function(latitude, longitude, width, heigh
  * @returns {Image} Image of requested location with specified size and orientation
  */
 GoogleStreetView.getViewFromAddress = function(location, width, height, fieldofview, heading, pitch) {
-    return this._sendImage({queryString: `size=${width}x${height}&location=${location}&fov=${fieldofview}&heading=${heading}&pitch=${pitch}&key=${key}`, method: 'GET'});
+    return this._sendImage({queryString: `?size=${width}x${height}&location=${location}&fov=${fieldofview}&heading=${heading}&pitch=${pitch}&key=${key}`, method: 'GET'});
 };
 
 GoogleStreetView.serviceName = 'GoogleStreetView';

--- a/src/server/rpc/procedures/google-streetview/google-streetview.js
+++ b/src/server/rpc/procedures/google-streetview/google-streetview.js
@@ -38,7 +38,7 @@ GoogleStreetView.getViewFromLatLong = function(latitude, longitude, width, heigh
 
 /**
  * Get Street View image of a location from a location string
- * @param {String} address Address or Name of location
+ * @param {String} location Address or Name of location
  * @param {BoundedNumber<1,2000>} width Width of image
  * @param {BoundedNumber<1,2000>} height Height of image
  * @param {BoundedNumber<1,120>} fieldofview Field of View of image, maximum of 120

--- a/src/server/rpc/procedures/google-streetview/google-streetview.js
+++ b/src/server/rpc/procedures/google-streetview/google-streetview.js
@@ -50,6 +50,50 @@ GoogleStreetView.getViewFromAddress = function(location, width, height, fieldofv
     return this._sendImage({queryString: `?size=${width}x${height}&location=${location}&fov=${fieldofview}&heading=${heading}&pitch=${pitch}&key=${key}`, method: 'GET'});
 };
 
+
+/**
+ * Get Street View metadata of a location using coordinates.
+ * Status explanation: "OK" Indicates that no errors occurred.
+ * "ZERO_RESULTS" Indicates that no panorama could be found near the provided location.
+ * "NOT_FOUND" Indicates that the address string provided in the location parameter could not be found.
+ * @param {Latitude} latitude Latitude coordinate of location
+ * @param {Longitude} longitude Longitude coordinate of location
+ * @param {BoundedNumber<1,2000>} width Width of image
+ * @param {BoundedNumber<1,2000>} height Height of image
+ * @param {BoundedNumber<1,120>} fieldofview Field of View of image, maximum of 120
+ * @param {BoundedNumber<0,360>} heading Heading of view
+ * @param {BoundedNumber<-90,90>} pitch Pitch of view, 90 to point up, -90 to point down
+ * @returns {Object} Metadata infromation about the requested Street View.
+ */
+GoogleStreetView.getMetadataFromLatLong = function(latitude, longitude, width, height, fieldofview, heading, pitch) {
+    const queryOpts = {
+        queryString: `/metadata?size=${width}x${height}&location=${latitude},${longitude}&fov=${fieldofview}&heading=${heading}&pitch=${pitch}&key=${key}`
+    };
+    const parserFn = resp => resp; // explicitly do nothing
+    return this._sendStruct(queryOpts, parserFn);
+};
+
+/**
+ * Get Street View metadata of a location using a location query.
+ * Status explanation: "OK": No errors occurred.
+ * "ZERO_RESULTS": No image could be found near the provided location.
+ * "NOT_FOUND": The location provided could not be found.
+ * @param {String} location Address or Name of location
+ * @param {BoundedNumber<1,2000>} width Width of image
+ * @param {BoundedNumber<1,2000>} height Height of image
+ * @param {BoundedNumber<1,120>} fieldofview Field of View of image, maximum of 120
+ * @param {BoundedNumber<0,360>} heading Heading of view
+ * @param {BoundedNumber<-90,90>} pitch Pitch of view, 90 to point up, -90 to point down
+ * @returns {Object} Metadata infromation about the requested Street View.
+ */
+GoogleStreetView.getMetadataFromAddress = function(location, width, height, fieldofview, heading, pitch) {
+    const queryOpts = {
+        queryString: `/metadata?size=${width}x${height}&location=${location}&fov=${fieldofview}&heading=${heading}&pitch=${pitch}&key=${key}`
+    };
+    const parserFn = resp => resp; // explicitly do nothing
+    return this._sendStruct(queryOpts, parserFn);
+};
+
 GoogleStreetView.serviceName = 'GoogleStreetView';
 
 module.exports = GoogleStreetView;


### PR DESCRIPTION
adds two RPCs to the OpenStreetMap service. It allows for a programmatical way of checking whether a given location has imagery or not