### PR TITLE
renamed leftover rpcName from #1368

### DIFF
--- a/test/assets/mock-rpc.js
+++ b/test/assets/mock-rpc.js
@@ -24,7 +24,7 @@ var MockRPC = function(RPC, raw) {
     this.response = new MockResponse();
     this.request = new MockRequest();
 
-    this.rpcName = this._rpc.rpcName;
+    this.serviceName = this._rpc.serviceName;
 };
 
 MockRPC.prototype.getNewSocket = function() {

--- a/test/assets/utils.js
+++ b/test/assets/utils.js
@@ -173,7 +173,7 @@ const sleep = delay => {
 
 module.exports = {
     verifyRPCInterfaces: function(rpc, interfaces) {
-        describe(`${rpc.rpcName} interfaces`, function() {
+        describe(`${rpc.serviceName} interfaces`, function() {
             interfaces.forEach(interface => {
                 var name = interface[0],
                     expected = interface[1] || [];

--- a/test/unit/server/rpc/jsdoc-extractor.spec.js
+++ b/test/unit/server/rpc/jsdoc-extractor.spec.js
@@ -165,10 +165,10 @@ describe('jsdoc-extractor', () => {
         describe('getDocFor', () => {
             it('should return a copy', () => {
                 let Docs = jp.Docs;
-                let sampleDocs = {rpcs: [{name: 'rpcName', description: 'original description'}]};
-                let targetDoc = Docs.prototype.getDocFor.call(sampleDocs, 'rpcName');
+                let sampleDocs = {rpcs: [{name: 'serviceName', description: 'original description'}]};
+                let targetDoc = Docs.prototype.getDocFor.call(sampleDocs, 'serviceName');
                 targetDoc.description = 'mutated description';
-                let secondGet = Docs.prototype.getDocFor.call(sampleDocs, 'rpcName');
+                let secondGet = Docs.prototype.getDocFor.call(sampleDocs, 'serviceName');
                 assert.deepEqual(secondGet.description, 'original description');
             });
         });


### PR DESCRIPTION
fixes `undefined interface` logs