### PR TITLE
intentional vs unintentional rpc exception handling fixes #2350

### DIFF
--- a/src/server/rpc/rpc-manager.js
+++ b/src/server/rpc/rpc-manager.js
@@ -369,9 +369,18 @@ RPCManager.prototype.sendRPCResult = function(response, result) {
 };
 
 RPCManager.prototype.sendRPCError = function(response, error) {
-    this._logger.error(`Uncaught exception: ${error.toString()}`);
-    if (response.headersSent) return;
-    response.status(500).send(error.message);
+    const isIntentionalError = err => err.name === 'Name';
+    if (isIntentionalError(error)) {
+        // less descriptive logs and send the error message to the user
+        this._logger.error(`Uncaught exception: ${error.message}`);
+        if (response.headersSent) return;
+        response.status(500).send(error.message);
+    } else {
+        // more verbose logs. hide the error message from user (generic error)
+        this._logger.error('Uncaught exception:', error);
+        if (response.headersSent) return;
+        response.status(500).send('something went wrong');
+    }
 };
 
 RPCManager.prototype.isRPCLoaded = function(rpcPath) {

--- a/src/server/rpc/rpc-manager.js
+++ b/src/server/rpc/rpc-manager.js
@@ -372,7 +372,7 @@ RPCManager.prototype.sendRPCError = function(response, error) {
     const isIntentionalError = err => err.name === 'Name';
     if (isIntentionalError(error)) {
         // less descriptive logs and send the error message to the user
-        this._logger.error(`Uncaught exception: ${error.message}`);
+        this._logger.error(`Error caught: ${error.message}`);
         if (response.headersSent) return;
         response.status(500).send(error.message);
     } else {


### PR DESCRIPTION
 the logic of detecting intentional vs unintentional could use some work

// less descriptive logs and send the error message to the user
// more verbose logs. hide the error message from user (generic error)

- avoids leaking error information to the end users
- no scary error messages for the end user
- provides better error logs for important (unintentional) unhandled service exceptions