### PR TITLE
roboscape: extendable cipher fixes #2394

### DIFF
--- a/src/server/rpc/procedures/roboscape/ciphers.js
+++ b/src/server/rpc/procedures/roboscape/ciphers.js
@@ -1,0 +1,39 @@
+
+// key is an array of shift values
+const caesarCipher = (text, key, decrypt=false) => {
+    if (typeof text !== 'string') {
+        return false;
+    } else if (key.length === 0) {
+        return text;
+    }
+
+    var output = '';
+    for (var i = 0; i < text.length; i++) {
+        var code = text.charCodeAt(i),
+            shift = +key[i % key.length];
+
+        code = decrypt ? code - shift : code + shift;
+        code = (code - 32) % (127 - 32);
+        if (code < 0) {
+            code += 127 - 32;
+        }
+        code += 32;
+
+        output += String.fromCharCode(code);
+    }
+    return output;
+};
+
+
+
+module.exports = {
+    plain: { // ignores the second argument key
+        encrypt: text => text,
+        decrypt: text => text,
+    },
+
+    caesar: {
+        encrypt: (text, key) => caesarCipher(text, key, false),
+        decrypt: (text, key) => caesarCipher(text, key, true),
+    },
+};

--- a/src/server/rpc/procedures/roboscape/roboscape.js
+++ b/src/server/rpc/procedures/roboscape/roboscape.js
@@ -321,7 +321,7 @@ if (ROBOSCAPE_MODE === 'security' || ROBOSCAPE_MODE === 'both') {
         if (!robot && typeof command !== 'string') return false;
 
         // figure out the raw command after processing special methods, encryption, seq and client rate
-        if (command.match(/^backdoor[, ](.*)$/)) { // check if it is a backdoor
+        if (command.match(/^backdoor[, ](.*)$/)) { // if it is a backdoor directly set the command
             logger.log('executing ' + command);
             command = RegExp.$1;
         } else { // if not a backdoor handle seq number and encryption

--- a/src/server/rpc/procedures/roboscape/roboscape.js
+++ b/src/server/rpc/procedures/roboscape/roboscape.js
@@ -328,7 +328,8 @@ if (ROBOSCAPE_MODE === 'security' || ROBOSCAPE_MODE === 'both') {
             // for replay attacks
             robot.commandToClient(command);
 
-            command = robot.decrypt(command);
+            if (robot._hasValidEncryptionSet()) // if encryption is set
+                command = robot.decrypt(command);
 
             var seqNum = -1;
             if (command.match(/^(\d+)[, ](.*)$/)) {

--- a/src/server/rpc/procedures/roboscape/robot.js
+++ b/src/server/rpc/procedures/roboscape/robot.js
@@ -645,7 +645,6 @@ Robot.prototype.randomEncryption = function () {
     blinks.push(3);
     this.resetSeqNum();
     this.resetRates();
-    // TODO make it compatible with speck keys
     this.setEncryptionKey(keys);
     this.playBlinks(blinks);
 };

--- a/src/server/rpc/procedures/roboscape/robot.js
+++ b/src/server/rpc/procedures/roboscape/robot.js
@@ -3,6 +3,7 @@ const getRPCLogger = require('../utils/logger');
 const NetworkTopology = require('../../../network-topology');
 const acl = require('./accessControl');
 const ROBOSCAPE_MODE = process.env.ROBOSCAPE_MODE || 'both';
+const ciphers = require('./ciphers');
 
 // these might be better defined as an attribute on the robot
 const FORGET_TIME = 120; // forgetting a robot in seconds
@@ -17,7 +18,8 @@ var Robot = function (mac_addr, ip4_addr, ip4_port, aServer) {
     this.timestamp = -1; // time of last message in robot time
     this.sockets = []; // uuids of sockets of registered clients
     this.callbacks = {}; // callbacks keyed by msgType
-    this.encryption = []; // encryption key
+    this.encryptionKey = []; // encryption key
+    this.encryptionMethod = ciphers.caesar;
     this.buttonDownTime = 0; // last time button was pressed
     // rate control
     this.totalCount = 0; // in messages per second
@@ -342,7 +344,7 @@ Robot.prototype.onMessage = function (message) {
         if (this.timestamp < oldTimestamp) {
             this._logger.log('robot was rebooted ' + this.mac_addr);
             this.setSeqNum(-1);
-            this.setEncryption([]);
+            this.setEncryptionKey([]);
             this.resetRates();
         }
     } else if (command === 'B' && message.length === 15) {
@@ -460,13 +462,20 @@ Robot.prototype.onCommand = function(command) {
             }
         },
         {
+            regex: /^set cipher ([^ ]+)$/, // name of the cipher
+            handler: () => {
+                let cipherName = RegExp.$1.toLoweCase();
+                return this.setEncryptionMethod(cipherName);
+            }
+        },
+        {
             regex: /^set key(| -?\d+([ ,]-?\d+)*)$/,
             handler: () => {
                 var encryption = RegExp.$1.split(/[, ]/);
                 if (encryption[0] === '') {
                     encryption.splice(0, 1);
                 }
-                return this.setEncryption(encryption.map(Number));
+                return this.setEncryptionKey(encryption.map(Number));
             }
         },
         {
@@ -515,43 +524,45 @@ Robot.prototype.onCommand = function(command) {
     return rv;
 };
 
-Robot.prototype.encrypt = function (text, decrypt) {
-    if (typeof text !== 'string') {
-        return false;
-    } else if (this.encryption.length === 0) {
-        return text;
-    }
-
-    var output = '';
-    for (var i = 0; i < text.length; i++) {
-        var code = text.charCodeAt(i),
-            shift = +this.encryption[i % this.encryption.length];
-
-        code = decrypt ? code - shift : code + shift;
-        code = (code - 32) % (127 - 32);
-        if (code < 0) {
-            code += 127 - 32;
-        }
-        code += 32;
-
-        output += String.fromCharCode(code);
-    }
-    this._logger.log('"' + text + '" ' + (decrypt ? 'decrypted' : 'encrypted') +
-        ' to "' + output + '"');
+Robot.prototype.encrypt = function (text) {
+    let output = this.encryptionMethod.encrypt(text, this.encryptionKey);
+    this._logger.log('"' + text + '" encrypted to "' + output + '"');
     return output;
 };
 
 Robot.prototype.decrypt = function (text) {
-    return this.encrypt(text, true);
+    let output = this.encryptionMethod.decrypt(text, this.encryptionKey);
+    this._logger.log('"' + text + '" decrypted to "' + output + '"');
+    return output;
 };
 
-Robot.prototype.setEncryption = function (keys) {
-    if (keys instanceof Array) {
-        this.encryption = keys;
+
+// disable encryption and decryption with minimal changes
+Robot.prototype.disableEncryption = function () {
+    this.encryptionMethod = ciphers.plain;
+};
+
+Robot.prototype.setEncryptionMethod = function (name) {
+    if (!ciphers[name]) {
+        this._logger.warn('invalid cipher name ' + name);
+        return false;
+    }
+
+    this.encryptionMethod = ciphers[name];
+    return true;
+};
+
+// WARN keys number?
+Robot.prototype.setEncryptionKey = function (keys) {
+    if (!this.encryptionMethod) {
+        this._logger.warn('setting the key without a cipher ' + keys);
+        return false;
+    } else if (keys instanceof Array) {
+        this.encryptionKey = keys;
         this._logger.log(this.mac_addr + ' encryption set to [' + keys + ']');
         return true;
     } else {
-        this._logger.log('invalid encryption key ' + keys);
+        this._logger.warn('invalid encryption key ' + keys);
         return false;
     }
 };
@@ -600,14 +611,14 @@ Robot.prototype.randomEncryption = function () {
     blinks.push(3);
     this.setSeqNum(-1);
     this.resetRates();
-    this.setEncryption(keys);
+    this.setEncryptionKey(keys);
     this.playBlinks(blinks);
 };
 
 Robot.prototype.resetEncryption = function () {
     this.setSeqNum(-1);
     this.resetRates();
-    this.setEncryption([]);
+    this.setEncryptionKey([]);
     this.playBlinks([3]);
 };
 

--- a/src/server/rpc/procedures/roboscape/robot.js
+++ b/src/server/rpc/procedures/roboscape/robot.js
@@ -317,7 +317,7 @@ Robot.prototype.sendToClient = function (msgType, content) {
 
                 const encryptedContent = {
                     robot: myself.mac_addr,
-                    message: myself.encrypt(text.trim())
+                    message: this._hasValidEncryptionSet() ? myself.encrypt(text.trim()) : text.trim()
                 };
                 socket.sendMessage('robot message', encryptedContent);
             }
@@ -524,13 +524,27 @@ Robot.prototype.onCommand = function(command) {
     return rv;
 };
 
+
+// determines whether encryption/decryption can be activated or not
+Robot.prototype._hasValidEncryptionSet = function () {
+    let verdict = (this.encryptionKey && this.encryptionMethod && Array.isArray(this.encryptionKey) && this.encryptionKey.length !== 0);
+    return verdict;
+};
+
+
 Robot.prototype.encrypt = function (text) {
+    if (!this._hasValidEncryptionSet()) {
+        throw new Error('invalid encryption setup');
+    }
     let output = this.encryptionMethod.encrypt(text, this.encryptionKey);
     this._logger.log('"' + text + '" encrypted to "' + output + '"');
     return output;
 };
 
 Robot.prototype.decrypt = function (text) {
+    if (!this._hasValidEncryptionSet()) {
+        throw new Error('invalid encryption setup');
+    }
     let output = this.encryptionMethod.decrypt(text, this.encryptionKey);
     this._logger.log('"' + text + '" decrypted to "' + output + '"');
     return output;

--- a/src/server/rpc/procedures/roboscape/robot.js
+++ b/src/server/rpc/procedures/roboscape/robot.js
@@ -51,10 +51,13 @@ Robot.prototype.resetRates = function () {
     this.clientCounts = {};
 };
 
+// resets the encryption
+// for backward compat sets it to caesar cipher with key [0]
 Robot.prototype.resetEncryption = function () {
     this._logger.log('resetting encryption');
-    this.encryptionMethod = null;
-    this.encryptionKey = null;
+    // null would make more sense but keeping backward compatibility here
+    this.encryptionMethod = ciphers.caesar;
+    this.encryptionKey = [0];
 };
 
 Robot.prototype.resetSeqNum = function () {

--- a/src/server/rpc/procedures/roboscape/robot.js
+++ b/src/server/rpc/procedures/roboscape/robot.js
@@ -18,8 +18,8 @@ var Robot = function (mac_addr, ip4_addr, ip4_port, aServer) {
     this.timestamp = -1; // time of last message in robot time
     this.sockets = []; // uuids of sockets of registered clients
     this.callbacks = {}; // callbacks keyed by msgType
-    this.encryptionKey = undefined; // encryption key
-    this.encryptionMethod = ciphers.plain;
+    this.encryptionKey = [0]; // encryption key
+    this.encryptionMethod = ciphers.caesar; // backward compat
     this.buttonDownTime = 0; // last time button was pressed
     // rate control
     this.totalCount = 0; // in messages per second

--- a/src/server/rpc/procedures/roboscape/robot.js
+++ b/src/server/rpc/procedures/roboscape/robot.js
@@ -477,13 +477,17 @@ Robot.prototype.onCommand = function(command) {
             }
         },
         {
-            regex: /^set cipher ([^ ]+)$/, // name of the cipher
+            regex: /^set encryption ([^ ]+)(| -?\d+([ ,]-?\d+)*)$/, // name of the cipher
             handler: () => {
-                let cipherName = RegExp.$1.toLoweCase();
-                return this.setEncryptionMethod(cipherName);
+                let cipherName = RegExp.$1.toLowerCase();
+                var key = RegExp.$2.split(/[, ]/);
+                if (key[0] === '') {
+                    key.splice(0, 1);
+                }
+                return this.setEncryptionMethod(cipherName) && this.setEncryptionKey(key);
             }
         },
-        {
+        { // deprecated
             regex: /^set key(| -?\d+([ ,]-?\d+)*)$/,
             handler: () => {
                 var encryption = RegExp.$1.split(/[, ]/);
@@ -576,6 +580,7 @@ Robot.prototype.setEncryptionMethod = function (name) {
         this._logger.warn('invalid cipher name ' + name);
         return false;
     }
+    this._logger.log('setting cipher to ' + name);
 
     this.encryptionMethod = ciphers[name];
     return true;
@@ -588,7 +593,7 @@ Robot.prototype.setEncryptionKey = function (keys) {
         return false;
     } else if (keys instanceof Array) {
         this.encryptionKey = keys;
-        this._logger.log(this.mac_addr + ' encryption set to [' + keys + ']');
+        this._logger.log(this.mac_addr + ' encryption key set to [' + keys + ']');
         return true;
     } else {
         this._logger.warn('invalid encryption key ' + keys);

--- a/src/server/rpc/procedures/roboscape/robot.js
+++ b/src/server/rpc/procedures/roboscape/robot.js
@@ -18,8 +18,8 @@ var Robot = function (mac_addr, ip4_addr, ip4_port, aServer) {
     this.timestamp = -1; // time of last message in robot time
     this.sockets = []; // uuids of sockets of registered clients
     this.callbacks = {}; // callbacks keyed by msgType
-    this.encryptionKey = []; // encryption key
-    this.encryptionMethod = ciphers.caesar;
+    this.encryptionKey = undefined; // encryption key
+    this.encryptionMethod = ciphers.plain;
     this.buttonDownTime = 0; // last time button was pressed
     // rate control
     this.totalCount = 0; // in messages per second
@@ -615,10 +615,13 @@ Robot.prototype.randomEncryption = function () {
     this.playBlinks(blinks);
 };
 
+// resets encryption and sequencing
 Robot.prototype.resetEncryption = function () {
+    this._logger.log('resetting encryption and sequencing');
     this.setSeqNum(-1);
     this.resetRates();
-    this.setEncryptionKey([]);
+    this.setEncryptionMethod('plain');
+    this.setEncryptionKey();
     this.playBlinks([3]);
 };
 


### PR DESCRIPTION
refactored robots to support multiple ciphers.
keeps the default cipher as caesar cipher with [0] key

adds a new command to set the cipher: `set encryption CIPHERNAME keys`

- [ ] a command to reset cipher (or disable encryption)
- deprecates `set key ..`