### PR TITLE
roboscape: speck cipher support fixes: #2396

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -2,3 +2,6 @@
 	path = src/browser
 	url = https://github.com/netsblox/Snap--Build-Your-Own-Blocks
 	branch = netsblox
+[submodule "src/server/rpc/procedures/roboscape/speckjs"]
+	path = src/server/rpc/procedures/roboscape/speckjs
+	url = https://github.com/hamidzr/speckjs

--- a/src/server/rpc/procedures/roboscape/ciphers.js
+++ b/src/server/rpc/procedures/roboscape/ciphers.js
@@ -1,3 +1,4 @@
+const Speck32 = require('./speck.js');
 
 // key is an array of shift values
 const caesarCipher = (text, key, decrypt=false) => {
@@ -25,6 +26,8 @@ const caesarCipher = (text, key, decrypt=false) => {
 };
 
 
+const speck32 = new Speck32();
+
 
 module.exports = {
     plain: { // ignores the second argument key
@@ -36,4 +39,9 @@ module.exports = {
         encrypt: (text, key) => caesarCipher(text, key, false),
         decrypt: (text, key) => caesarCipher(text, key, true),
     },
+
+    speck: {
+        encrypt: (text, key) => speck32.encryptAscii(text, key),
+        decrypt: (text, key) => speck32.decryptAscii(text, key),
+    }
 };

--- a/src/server/rpc/procedures/roboscape/robot.js
+++ b/src/server/rpc/procedures/roboscape/robot.js
@@ -591,9 +591,10 @@ Robot.prototype.setEncryptionKey = function (keys) {
     if (!this.encryptionMethod) {
         this._logger.warn('setting the key without a cipher ' + keys);
         return false;
-    } else if (keys instanceof Array) {
+    } else if (keys instanceof Array) { // all the supported ciphers require an array of numbers
+        keys = keys.map(num => parseInt(num));
         this.encryptionKey = keys;
-        this._logger.log(this.mac_addr + ' encryption key set to [' + keys + ']');
+        this._logger.log(this.mac_addr, 'encryption key set to', keys);
         return true;
     } else {
         this._logger.warn('invalid encryption key ' + keys);

--- a/src/server/rpc/procedures/roboscape/speck.js
+++ b/src/server/rpc/procedures/roboscape/speck.js
@@ -1,0 +1,1 @@
+speckjs/src/ciphers/speckNative.js


### PR DESCRIPTION
- [x] support for the hardkey

depends on #2395 