### PR TITLE
roboscape return false when robot is not found fixes #2410

### DIFF
--- a/src/server/rpc/procedures/roboscape/roboscape.js
+++ b/src/server/rpc/procedures/roboscape/roboscape.js
@@ -318,7 +318,7 @@ if (ROBOSCAPE_MODE === 'security' || ROBOSCAPE_MODE === 'both') {
     RoboScape.prototype.send = async function (robot, command) {
         robot = await this._getRobot(robot);
 
-        if (!robot && typeof command !== 'string') return false;
+        if (!robot || typeof command !== 'string') return false;
 
         // figure out the raw command after processing special methods, encryption, seq and client rate
         if (command.match(/^backdoor[, ](.*)$/)) { // if it is a backdoor directly set the command


### PR DESCRIPTION
fixes a bad conditional that fails to catch undefined robot object