### PR TITLE
Fix regex for data lines in Antarctic Composite CO2 data. Fixes #2484

### DIFF
--- a/src/server/rpc/procedures/paleo-climate/data/antarctic-co2-composite/index.js
+++ b/src/server/rpc/procedures/paleo-climate/data/antarctic-co2-composite/index.js
@@ -5,7 +5,7 @@ const dataFile = path.join(__dirname, 'antarctica2015co2composite.txt');
 const lines = fs.readFileSync(dataFile, 'utf8').split('\n');
 
 // Remove all the headers and descriptions
-const dataRegex = /^[\d.]+\s+[\d.]+\s+[\d.]+/;
+const dataRegex = /^-?[\d.]+\s+[\d.]+\s+[\d.]+/;
 while (!dataRegex.test(lines[0])) {
     lines.shift();
 }


### PR DESCRIPTION
The data ingestion was filtering out the data with a negative date. Since the date is reported in yearsBP, this omitted data after 1950.