### PR TITLE
Add "path", "url" options for requests in API consumer. Closes #2571

### DIFF
--- a/src/server/rpc/procedures/air-quality/air-quality.js
+++ b/src/server/rpc/procedures/air-quality/air-quality.js
@@ -18,7 +18,7 @@ const logger = require('../utils/logger')('air-quality'),
     fs = require('fs'),
     geolib = require('geolib');
 
-const AirConsumer = new ApiConsumer('AirQuality', `http://www.airnowapi.org/aq/observation/zipCode/current/?format=application/json&API_KEY=${API_KEY}`,{cache: {ttl: 30*60}});
+const AirConsumer = new ApiConsumer('AirQuality', 'http://www.airnowapi.org/aq/observation/zipCode/current/',{cache: {ttl: 30*60}});
 
 var reportingLocations = (function() {  // Parse csv
     var locationPath = path.join(__dirname, 'air-reporting-locations.csv'),
@@ -39,6 +39,10 @@ var reportingLocations = (function() {  // Parse csv
             };
         });
 })();
+
+const queryString = function(zipCode) {
+    return `?format=application/json&API_KEY=${API_KEY}&zipCode=${zipCode}`;
+};
 
 /**
  * Get ZIP code of closest reporting location for coordinates
@@ -78,7 +82,7 @@ AirConsumer.qualityIndexByZipCode = function(zipCode) {
 
     logger.trace(`Requesting air quality at ${zipCode}`);
 
-    return this._sendAnswer({queryString: `&zipCode=${zipCode}`}, '.AQI')
+    return this._sendAnswer({queryString: queryString(zipCode)}, '.AQI')
         .catch(err => {
 
             logger.error('Could not get air quality index: ', err);

--- a/src/server/rpc/procedures/british-museum/british-museum.js
+++ b/src/server/rpc/procedures/british-museum/british-museum.js
@@ -55,7 +55,8 @@ const queryOptions = {
         'accept-language': 'en,fa;q=0.8'
     },
     method: 'POST',
-    queryString: 'sparql?',
+    path: 'sparql',
+    queryString: '?',
     body: undefined,
     json: false
 };
@@ -242,7 +243,8 @@ britishmuseum.getImage = function getImage(imageId, maxWidth, maxHeight) {
     maxHeight = maxHeight || 300;
     this._sendImage({
         baseUrl: 'http://www.britishmuseum.org/collectionimages/',
-        queryString: `AN${imageId.substr(0,5)}/AN${imageId}_001_l.jpg?maxwidth=${maxWidth}&maxheight=${maxHeight}`,
+        path: `AN${imageId.substr(0,5)}/AN${imageId}_001_l.jpg`,
+        queryString: `maxwidth=${maxWidth}&maxheight=${maxHeight}`,
         cache: true
     });
 

--- a/src/server/rpc/procedures/google-streetview/google-streetview.js
+++ b/src/server/rpc/procedures/google-streetview/google-streetview.js
@@ -83,7 +83,8 @@ GoogleStreetView.getViewFromAddress = function(location, width, height, fieldofv
  */
 GoogleStreetView.getInfo = function(latitude, longitude, width, height, fieldofview, heading, pitch) {
     const queryOpts = {
-        queryString: `/metadata?location=${latitude},${longitude}&fov=${fieldofview}&heading=${heading}&pitch=${pitch}&key=${key}`
+        path: '/metadata',
+        queryString: `?location=${latitude},${longitude}&fov=${fieldofview}&heading=${heading}&pitch=${pitch}&key=${key}`
     };
     const parserFn = resp => resp; // explicitly do nothing
     return this._sendStruct(queryOpts, parserFn);
@@ -102,7 +103,8 @@ GoogleStreetView.getInfo = function(latitude, longitude, width, height, fieldofv
  */
 GoogleStreetView.getInfoFromAddress = function(location, width, height, fieldofview, heading, pitch) {
     const queryOpts = {
-        queryString: `/metadata?location=${location}&fov=${fieldofview}&heading=${heading}&pitch=${pitch}&key=${key}`
+        path: '/metadata',
+        queryString: `?location=${location}&fov=${fieldofview}&heading=${heading}&pitch=${pitch}&key=${key}`
     };
     const parserFn = resp => resp; // explicitly do nothing
     return this._sendStruct(queryOpts, parserFn);
@@ -119,7 +121,8 @@ GoogleStreetView.getInfoFromAddress = function(location, width, height, fieldofv
  */
 GoogleStreetView.isAvailable = function(latitude, longitude, fieldofview, heading, pitch) {
     const queryOpts = {
-        queryString: `/metadata?location=${latitude},${longitude}&fov=${fieldofview}&heading=${heading}&pitch=${pitch}&key=${key}`
+        path: '/metadata',
+        queryString: `?location=${latitude},${longitude}&fov=${fieldofview}&heading=${heading}&pitch=${pitch}&key=${key}`
     };
     const parserFn = resp => resp.status === 'OK';
     return this._sendStruct(queryOpts, parserFn);
@@ -135,7 +138,8 @@ GoogleStreetView.isAvailable = function(latitude, longitude, fieldofview, headin
  */
 GoogleStreetView.isAvailableFromAddress = function(location, fieldofview, heading, pitch) {
     const queryOpts = {
-        queryString: `/metadata?location=${location}&fov=${fieldofview}&heading=${heading}&pitch=${pitch}&key=${key}`
+        path: '/metadata',
+        queryString: `?location=${location}&fov=${fieldofview}&heading=${heading}&pitch=${pitch}&key=${key}`
     };
     const parserFn = resp => resp.status === 'OK';
     return this._sendStruct(queryOpts, parserFn);

--- a/src/server/rpc/procedures/iex-trading/iex-trading.js
+++ b/src/server/rpc/procedures/iex-trading/iex-trading.js
@@ -21,8 +21,12 @@ const rewordError = err => {
  */
 StockConsumer.currentPrice = function(companySymbol) {
     companySymbol = companySymbol.toUpperCase();
+    const options = {
+        path: `/stock/${companySymbol}/quote`,
+        queryString: 'displayPercent=true',
+    };
 
-    return this._sendAnswer({queryString: `/stock/${companySymbol}/quote?displayPercent=true`}, '.latestPrice')
+    return this._sendAnswer(options, '.latestPrice')
         .catch(err => {
             const prettyError = rewordError(err);
             if (prettyError) {
@@ -39,8 +43,12 @@ StockConsumer.currentPrice = function(companySymbol) {
  */
 StockConsumer.lastOpenPrice = function(companySymbol) {
     companySymbol = companySymbol.toUpperCase();
+    const options = {
+        path: `/stock/${companySymbol}/quote`,
+        queryString: 'displayPercent=true',
+    };
 
-    return this._sendAnswer({queryString: `/stock/${companySymbol}/quote?displayPercent=true`}, '.open')
+    return this._sendAnswer(options, '.open')
         .catch(err => {
             const prettyError = rewordError(err);
             if (prettyError) {
@@ -57,8 +65,12 @@ StockConsumer.lastOpenPrice = function(companySymbol) {
  */
 StockConsumer.lastClosePrice = function(companySymbol) {
     companySymbol = companySymbol.toUpperCase();
+    const options = {
+        path: `/stock/${companySymbol}/quote`,
+        queryString: 'displayPercent=true',
+    };
 
-    return this._sendAnswer({queryString: `/stock/${companySymbol}/quote?displayPercent=true`}, '.close')
+    return this._sendAnswer(options, '.close')
         .catch(err => {
             const prettyError = rewordError(err);
             if (prettyError) {
@@ -75,8 +87,12 @@ StockConsumer.lastClosePrice = function(companySymbol) {
  */
 StockConsumer.companyInformation = function(companySymbol) {
     companySymbol = companySymbol.toUpperCase();
+    const options = {
+        path: `/stock/${companySymbol}/quote`,
+        queryString: 'displayPercent=true',
+    };
 
-    return this._sendAnswer({queryString: `/stock/${companySymbol}/quote?displayPercent=true`})
+    return this._sendAnswer(options)
         .catch(err => {
             const prettyError = rewordError(err);
             if (prettyError) {
@@ -93,8 +109,12 @@ StockConsumer.companyInformation = function(companySymbol) {
 */
 StockConsumer.dailyPercentChange = function(companySymbol) {
     companySymbol = companySymbol.toUpperCase();
+    const options = {
+        path: `/stock/${companySymbol}/quote`,
+        queryString: 'displayPercent=true',
+    };
 
-    return this._sendAnswer({queryString: `/stock/${companySymbol}/quote?displayPercent=true`}, '.changePercent')
+    return this._sendAnswer(options, '.changePercent')
         .catch(err => {
             const prettyError = rewordError(err);
             if (prettyError) {
@@ -113,7 +133,7 @@ StockConsumer.dailyPercentChange = function(companySymbol) {
 StockConsumer.historicalClosingPrices = function(companySymbol, range) {
     companySymbol = companySymbol.toUpperCase();
 
-    return this._requestData({queryString: `/stock/${companySymbol}/chart/${range}`})
+    return this._requestData({path: `/stock/${companySymbol}/chart/${range}`})
         .then(res => {
             return res.map(price => [price.date, price.close]);
         })

--- a/src/server/rpc/procedures/met-museum/met-museum.js
+++ b/src/server/rpc/procedures/met-museum/met-museum.js
@@ -78,7 +78,7 @@ MetMuseum.getImageUrls = async function(id) {
     }
 
     const queryOpts = {
-        queryString: `/objects/${id}`,
+        path: `/objects/${id}`,
     };
 
     const parserFn = resp => {

--- a/src/server/rpc/procedures/movie-db/movie-db.js
+++ b/src/server/rpc/procedures/movie-db/movie-db.js
@@ -293,7 +293,7 @@ MovieDB.personCrewReleaseDates = function(id) { return personCredits.call(this, 
 MovieDB.personCrewTitles = function(id) { return personCredits.call(this, id, 'crew', 'title'); };
 
 MovieDB.getImage = function(path){
-    return this._sendImage({queryString: path});
+    return this._sendImage({path});
 };
 
 MovieDB.isSupported = function() {

--- a/src/server/rpc/procedures/paralleldots/paralleldots.js
+++ b/src/server/rpc/procedures/paralleldots/paralleldots.js
@@ -22,10 +22,10 @@ const toLowerCaseKeys = object => {
     return result;
 };
 
-ParallelDots._parallelDotsRequest = function(query, text){
+ParallelDots._parallelDotsRequest = function(path, text){
     let body = `api_key=${key}&text=${encodeURI(text)}`;
     return this._sendAnswer({
-        queryString: query,
+        path: path,
         method: 'POST',
         headers: {'Content-Type' : 'application/x-www-form-urlencoded'},
         body: body
@@ -51,7 +51,7 @@ ParallelDots.getSentiment = async function(text) {
 ParallelDots.getSimilarity = async function(text1, text2) {
     const body = `api_key=${key}&text_1=${encodeURI(text1)}&text_2=${encodeURI(text2)}`;
     const result = await this._sendAnswer({
-        queryString: '/similarity', method: 'POST',
+        path: '/similarity', method: 'POST',
         headers: {'Content-Type' : 'application/x-www-form-urlencoded'},
         body: body
     });

--- a/src/server/rpc/procedures/pixabay/pixabay.js
+++ b/src/server/rpc/procedures/pixabay/pixabay.js
@@ -84,7 +84,7 @@ pixabay.searchAll = function (keywords, maxHeight, minHeight) {
  * @param {String} url URL of the image to retrieve
  */
 pixabay.getImage = function(url){
-    return this._sendImage({queryString: '', baseUrl:url});
+    return this._sendImage({url});
 };
 
 pixabay.isSupported = () => {

--- a/src/server/rpc/procedures/thing-speak/thing-speak.js
+++ b/src/server/rpc/procedures/thing-speak/thing-speak.js
@@ -69,9 +69,9 @@ thingspeakIoT._paginatedQueryOpts = function(queryOpts, limit) {
         const pages = Math.min(availablePages, Math.ceil(limit/perPage));
         let queryOptsList = [];
         for(let i = 1; i <= pages; i++){
-            queryOptsList.push({
-                queryString: queryOpts.queryString + `&page=${i}`
-            });
+            const options = Object.assign({}, queryOpts);
+            options.queryString += `&page=${i}`;
+            queryOptsList.push(options);
         }
         return queryOptsList;
     });

--- a/src/server/rpc/procedures/translation/translation.js
+++ b/src/server/rpc/procedures/translation/translation.js
@@ -31,14 +31,16 @@ TranslationConsumer._get_guid = function () {
 TranslationConsumer.translate = function(text, from, to) {
     let body = [{'Text' : text}];
     let guid = this._get_guid();
-    let query = `translate?api-version=3.0&to=${to}`;
+    let query = `?api-version=3.0&to=${to}`;
 
     if(from)
     {
         query = query + `&from=${from}`;
     }
 
-    return this._sendAnswer({queryString: query,
+    return this._sendAnswer({
+        path: 'translate',
+        queryString: query,
         method: 'POST',
         headers: {
             'Content-Type' : 'application/json',
@@ -67,7 +69,9 @@ TranslationConsumer.toEnglish = function(text) {
 TranslationConsumer.detectLanguage = function(text) {
     let body = [{'Text' : text}];
     let guid = this._get_guid();
-    return this._sendAnswer({queryString: 'detect?api-version=3.0',
+    return this._sendAnswer({
+        path: 'detect',
+        queryString: '?api-version=3.0',
         method: 'POST',
         headers: {
             'Content-Type' : 'application/json',
@@ -84,7 +88,9 @@ TranslationConsumer.detectLanguage = function(text) {
  * @returns {Array} List of languages supported by the translator
  */
 TranslationConsumer.getSupportedLanguages = function() {
-    return this._sendAnswer({queryString: 'languages?api-version=3.0&scope=translation',
+    return this._sendAnswer({
+        path: 'languages',
+        queryString: '?api-version=3.0&scope=translation',
         headers: {
             'Content-Type' : 'application/json',
             'Ocp-Apim-Subscription-Key' : key}}, '.translation')

--- a/src/server/rpc/procedures/trivia/trivia.js
+++ b/src/server/rpc/procedures/trivia/trivia.js
@@ -26,7 +26,7 @@ Trivia.getRandomQuestion = function() {
         'invalid_count'
     ];
 
-    return this._requestData({queryString: '/random'})
+    return this._requestData({path: '/random'})
         .then(questions => {
             const [question] = questions.map(q => {
                 const cleanedQ = {};
@@ -45,7 +45,7 @@ Trivia.getRandomQuestion = function() {
  * @returns {Promise<String>}
  */
 Trivia.random = function() {
-    return this._requestData({queryString: '/random'})
+    return this._requestData({path: '/random'})
         .then(questions => {
             for (var i = questions.length; i--;) {
                 const content = {

--- a/src/server/rpc/procedures/twitter/twitter.js
+++ b/src/server/rpc/procedures/twitter/twitter.js
@@ -45,7 +45,8 @@ TwitterConsumer.isSupported = () => {
  */
 TwitterConsumer.recentTweets = function (screenName, count) {
     return this._requestData({
-        queryString: `statuses/user_timeline.json?screen_name=${screenName}&count=${count}`,
+        path: 'statuses/user_timeline.json',
+        queryString: `?screen_name=${screenName}&count=${count}`,
         headers: {
             Authorization: KEY,
             gzip: 'true'
@@ -68,7 +69,8 @@ TwitterConsumer.recentTweets = function (screenName, count) {
  */
 TwitterConsumer.followers = function (screenName) {
     return this._sendAnswer({
-        queryString: `users/show.json?screen_name=${screenName}`,
+        path: 'users/show.json',
+        queryString: `?screen_name=${screenName}`,
         headers: {
             Authorization: KEY,
             gzip: 'true'
@@ -88,7 +90,8 @@ TwitterConsumer.followers = function (screenName) {
  */
 TwitterConsumer.tweets = function (screenName) {
     return this._sendAnswer({
-        queryString: `users/show.json?screen_name=${screenName}`,
+        path: 'users/show.json',
+        queryString: `?screen_name=${screenName}`,
         headers: {
             Authorization: KEY,
             gzip: 'true'
@@ -111,7 +114,8 @@ TwitterConsumer.tweets = function (screenName) {
  */
 TwitterConsumer.search = function (keyword, count) {
     return this._requestData({
-        queryString: `search/tweets.json?q=${encodeURI(keyword)}&count=${count}`,
+        path: 'search/tweets.json',
+        queryString: `?q=${encodeURI(keyword)}&count=${count}`,
         headers: {
             Authorization: KEY,
             gzip: 'true'
@@ -138,7 +142,8 @@ TwitterConsumer.tweetsPerDay = function (screenName) {
         dateToday = new Date();
 
     return this._requestData({
-        queryString: `statuses/user_timeline.json?screen_name=${screenName}&count=200`,
+        path: 'statuses/user_timeline.json',
+        queryString: `?screen_name=${screenName}&count=200`,
         headers: {
             Authorization: KEY,
             gzip: 'true'
@@ -163,7 +168,8 @@ TwitterConsumer.tweetsPerDay = function (screenName) {
  */
 TwitterConsumer.favorites = function (screenName, count) {
     return this._requestData({
-        queryString: `favorites/list.json?screen_name=${screenName}&count=${count}`,
+        path: 'favorites/list.json',
+        queryString: `?screen_name=${screenName}&count=${count}`,
         headers: {
             Authorization: KEY,
             gzip: 'true'
@@ -187,7 +193,8 @@ TwitterConsumer.favorites = function (screenName, count) {
  */
 TwitterConsumer.favoritesCount = function (screenName) {
     return this._sendAnswer({
-        queryString: `users/show.json?screen_name=${screenName}`,
+        path: 'users/show.json',
+        queryString: `?screen_name=${screenName}`,
         headers: {
             Authorization: KEY,
             gzip: 'true'

--- a/src/server/rpc/procedures/utils/api-consumer.js
+++ b/src/server/rpc/procedures/utils/api-consumer.js
@@ -42,6 +42,7 @@ class ApiConsumer extends NBService {
 
     /**
         queryOptions = {
+            url,
             path,
             queryString,
             baseUrl,
@@ -56,8 +57,9 @@ class ApiConsumer extends NBService {
             queryOptions.queryString.replace(/^\??/, '?') : '';
         const path = queryOptions.path ?
             queryOptions.path.replace(/^\/?/, '/') : '';
-        const baseUrl = queryOptions.baseUrl || this._baseUrl;  // TODO: Does anyone use this option?
-        return queryOptions.url || baseUrl + path + queryString;
+
+        const baseUrl = queryOptions.baseUrl || this._baseUrl;
+        return queryOptions.url || (baseUrl + path + queryString);
     }
 
     _requestData(queryOptions){

--- a/src/server/rpc/procedures/utils/api-consumer.js
+++ b/src/server/rpc/procedures/utils/api-consumer.js
@@ -17,7 +17,7 @@ class ApiConsumer extends NBService {
         }, opts);
         super(name);
 
-        this._baseUrl = baseUrl;
+        this._baseUrl = baseUrl.replace(/\?$/, '').replace(/\/$/, '');
 
         // setup cache. maxsize is in bytes, ttl in seconds
         if (!fs.existsSync(opts.cache.path)) fs.mkdirSync(opts.cache.path); // ensure path exists

--- a/src/server/rpc/procedures/utils/api-consumer.js
+++ b/src/server/rpc/procedures/utils/api-consumer.js
@@ -42,6 +42,7 @@ class ApiConsumer extends NBService {
 
     /**
         queryOptions = {
+            path,
             queryString,
             baseUrl,
             method,
@@ -51,8 +52,12 @@ class ApiConsumer extends NBService {
         }
      */
     _getFullUrl(queryOptions){
-        const queryString = (queryOptions.queryString || '').replace(/^\??/, '?');
-        return (queryOptions.baseUrl || this._baseUrl) + queryString;
+        const queryString = queryOptions.queryString ?
+            queryOptions.queryString.replace(/^\??/, '?') : '';
+        const path = queryOptions.path ?
+            queryOptions.path.replace(/^\/?/, '/') : '';
+        const baseUrl = queryOptions.baseUrl || this._baseUrl;  // TODO: Does anyone use this option?
+        return queryOptions.url || baseUrl + path + queryString;
     }
 
     _requestData(queryOptions){

--- a/src/server/rpc/procedures/water-watch/water-watch.js
+++ b/src/server/rpc/procedures/water-watch/water-watch.js
@@ -6,7 +6,7 @@
  * @category Science
  */
 const ApiConsumer = require('../utils/api-consumer'),
-    waterwatch = new ApiConsumer('WaterWatch','https://waterservices.usgs.gov/nwis/iv/?');
+    waterwatch = new ApiConsumer('WaterWatch','https://waterservices.usgs.gov/nwis/iv/');
 
 
 // turn an options object into query friendly string

--- a/src/server/rpc/procedures/weather/weather.js
+++ b/src/server/rpc/procedures/weather/weather.js
@@ -31,13 +31,17 @@ const isWithinMaxDistance = function(result, lat, lng) {
     return distance < MAX_DISTANCE;
 };
 
+const queryString = function(latitude, longitude) {
+    return `APPID=${API_KEY}&lat=${latitude}&lon=${longitude}`;
+};
+
 /**
  * Get the current temperature for a given location.
  * @param {Latitude} latitude
  * @param {Longitude} longitude
  */
 weather.temperature = function(latitude, longitude){
-    return this._requestData({queryString: '&lat=' + latitude + '&lon=' + longitude})
+    return this._requestData({queryString: queryString(latitude, longitude)})
         .then(body => {
             var temp = 'unknown';
             if (body.main && isWithinMaxDistance(body, latitude, longitude)) {
@@ -65,7 +69,7 @@ weather.temp = function(latitude, longitude) {
  * @param {Longitude} longitude
  */
 weather.humidity = function(latitude, longitude){
-    return this._requestData({queryString: '&lat=' + latitude + '&lon=' + longitude})
+    return this._requestData({queryString: queryString(latitude, longitude)})
         .then(body => {
             var humidity = 'unknown';
             if (isWithinMaxDistance(body, latitude, longitude)) {
@@ -81,7 +85,7 @@ weather.humidity = function(latitude, longitude){
  * @param {Longitude} longitude
  */
 weather.description = function(latitude, longitude){
-    return this._requestData({queryString: '&lat=' + latitude + '&lon=' + longitude})
+    return this._requestData({queryString: queryString(latitude, longitude)})
         .then(body => {
             var description = 'unknown';
             if (isWithinMaxDistance(body, latitude, longitude)) {
@@ -97,7 +101,7 @@ weather.description = function(latitude, longitude){
  * @param {Longitude} longitude
  */
 weather.windSpeed = function(latitude, longitude){
-    return this._requestData({queryString: '&lat=' + latitude + '&lon=' + longitude})
+    return this._requestData({queryString: queryString(latitude, longitude)})
         .then(body => {
             var speed = 'unknown';
             if (isWithinMaxDistance(body, latitude, longitude)) {
@@ -113,7 +117,7 @@ weather.windSpeed = function(latitude, longitude){
  * @param {Longitude} longitude
  */
 weather.windAngle = function(latitude, longitude){
-    return this._requestData({queryString: '&lat=' + latitude + '&lon=' + longitude})
+    return this._requestData({queryString: queryString(latitude, longitude)})
         .then(body => {
             var deg = 'unknown';
             if (isWithinMaxDistance(body, latitude, longitude)) {
@@ -129,7 +133,7 @@ weather.windAngle = function(latitude, longitude){
  * @param {Longitude} longitude
  */
 weather.icon = function(latitude, longitude){
-    return this._requestData({queryString: '&lat=' + latitude + '&lon=' + longitude})
+    return this._requestData({queryString: queryString(latitude, longitude)})
         .then(body => {
             // Return sunny if unknown
             var iconName = '01d.png';
@@ -137,8 +141,7 @@ weather.icon = function(latitude, longitude){
                 iconName = body.weather[0].icon+'.png';
             }
             let queryOpts = {
-                queryString: iconName,
-                baseUrl: 'http://openweathermap.org/img/w/',
+                url: 'http://openweathermap.org/img/w/' + iconName,
             };
             return this._sendImage(queryOpts);
         });

--- a/src/server/rpc/procedures/weather/weather.js
+++ b/src/server/rpc/procedures/weather/weather.js
@@ -16,7 +16,7 @@ const API_KEY = process.env.OPEN_WEATHER_MAP_KEY;
 const MAX_DISTANCE = +process.env.WEATHER_MAX_DISTANCE || Infinity;  // miles
 const geolib = require('geolib');
 
-const weather = new ApiConsumer('Weather', 'http://api.openweathermap.org/data/2.5/weather?APPID='+API_KEY, {cache: {ttl: 60}});
+const weather = new ApiConsumer('Weather', 'http://api.openweathermap.org/data/2.5/weather', {cache: {ttl: 60}});
 
 const isWithinMaxDistance = function(result, lat, lng) {
     var distance = geolib.getDistance(

--- a/test/unit/server/rpc/procedures/utils/api-consumer.spec.js
+++ b/test/unit/server/rpc/procedures/utils/api-consumer.spec.js
@@ -19,7 +19,7 @@ describe('ApiConsumer', function(){
         });
     });
 
-    describe.only('_getFullUrl', () => {
+    describe('_getFullUrl', () => {
         const baseUrl = 'https://abc.com';
         const service = testRpc._rpc;
 

--- a/test/unit/server/rpc/procedures/utils/api-consumer.spec.js
+++ b/test/unit/server/rpc/procedures/utils/api-consumer.spec.js
@@ -19,6 +19,38 @@ describe('ApiConsumer', function(){
         });
     });
 
+    describe.only('_getFullUrl', () => {
+        const baseUrl = 'https://abc.com';
+        const service = testRpc._rpc;
+
+        it('should override url with "url" option', function() {
+            const options = {baseUrl, queryString: 'a=b&c=d'};
+            options.url = 'http://github.com';
+            const url = service._getFullUrl(options);
+            assert.equal(url, options.url);
+        });
+
+        it('should add ? before query string', function() {
+            const url = service._getFullUrl({baseUrl, queryString: 'a=b&c=d'});
+            assert.equal(url, `${baseUrl}?a=b&c=d`);
+        });
+
+        it('should not add ? before query string if exists', function() {
+            const url = service._getFullUrl({baseUrl, queryString: '?a=b&c=d'});
+            assert.equal(url, `${baseUrl}?a=b&c=d`);
+        });
+
+        it('should add / before path', function() {
+            const url = service._getFullUrl({baseUrl, path: 'test/path'});
+            assert.equal(url, `${baseUrl}/test/path`);
+        });
+
+        it('should not add / before path if exists', function() {
+            const url = service._getFullUrl({baseUrl, path: '/test/path'});
+            assert.equal(url, `${baseUrl}/test/path`);
+        });
+    });
+
     describe('requestData', ()=>{
 
         it('should get correct data from the endpoint', done => {


### PR DESCRIPTION
This updates API consumer to actually treat query strings like query strings and adds `path`, `url` options.