### PR TITLE
Deprecate IEXTrading. Closes #2486

### DIFF
--- a/src/server/rpc/procedures/iex-trading/iex-trading.js
+++ b/src/server/rpc/procedures/iex-trading/iex-trading.js
@@ -146,5 +146,11 @@ StockConsumer.historicalClosingPrices = function(companySymbol, range) {
         });
 };
 
+StockConsumer.isSupported = function() {
+    /* eslint-disable no-console */
+    console.error('IEXTrading API is no longer available as it has migrated to IEXCloud.');
+    /* eslint-enable no-console */
+    return false;
+};
 
 module.exports = StockConsumer;


### PR DESCRIPTION
This PR removes the IEXTrading service. Usage of old callRPC blocks using the service will result in the following error:

![DeepinScreenshot_select-area_20191112105635](https://user-images.githubusercontent.com/4982789/68692512-3d6d3d00-053b-11ea-9998-95f3d2b48d89.png)
