### PR TITLE
Update services to support custom API keys. Closes #2661

### DIFF
--- a/src/server/services/procedures/air-quality/air-quality.js
+++ b/src/server/services/procedures/air-quality/air-quality.js
@@ -19,7 +19,7 @@ const logger = require('../utils/logger')('air-quality'),
     geolib = require('geolib');
 
 const AirConsumer = new ApiConsumer('AirQuality', 'http://www.airnowapi.org/aq/observation/zipCode/current/',{cache: {ttl: 30*60}});
-ApiConsumer.setRequiredAPIKey(AirConsumer, AirNowKey);
+ApiConsumer.setRequiredApiKey(AirConsumer, AirNowKey);
 
 var reportingLocations = (function() {  // Parse csv
     var locationPath = path.join(__dirname, 'air-reporting-locations.csv'),

--- a/src/server/services/procedures/geolocation/geolocation.js
+++ b/src/server/services/procedures/geolocation/geolocation.js
@@ -5,7 +5,10 @@
  * Terms of service: https://developers.google.com/maps/terms
  * @service
  */
+const {GoogleMapsKey} = require('../utils/api-key');
+const utils = require('../utils');
 const GeoLocationRPC = {};
+utils.setRequiredAPIKey(GeoLocationRPC, GoogleMapsKey);
 const logger = require('../utils/logger')('geolocation');
 
 const CacheManager = require('cache-manager');
@@ -168,7 +171,7 @@ GeoLocationRPC.nearbySearch = function (latitude, longitude, keyword, radius) {
             location: latitude + ',' + longitude,
             radius: radius,
             // rankby: 'distance',
-            key: GEOCODER_API
+            key: this.apiKey.value
         },
         json: true
     };
@@ -200,14 +203,5 @@ function showError(err, response) {
     // if we can't answer their question return snap null
     response.send('null');
 }
-
-GeoLocationRPC.isSupported = function() {
-    if(!process.env.GOOGLE_GEOCODING_API){
-        /* eslint-disable no-console*/
-        console.error('GOOGLE_GEOCODING_API is missing.');
-        /* eslint-enable no-console*/
-    }
-    return !!process.env.GOOGLE_GEOCODING_API;
-};
 
 module.exports = GeoLocationRPC;

--- a/src/server/services/procedures/geolocation/geolocation.js
+++ b/src/server/services/procedures/geolocation/geolocation.js
@@ -8,7 +8,7 @@
 const {GoogleMapsKey} = require('../utils/api-key');
 const utils = require('../utils');
 const GeoLocationRPC = {};
-utils.setRequiredAPIKey(GeoLocationRPC, GoogleMapsKey);
+utils.setRequiredApiKey(GeoLocationRPC, GoogleMapsKey);
 const logger = require('../utils/logger')('geolocation');
 
 const CacheManager = require('cache-manager');

--- a/src/server/services/procedures/google-maps/google-maps.js
+++ b/src/server/services/procedures/google-maps/google-maps.js
@@ -10,12 +10,12 @@
 const logger = require('../utils/logger')('google-maps');
 const utils = require('../utils');
 const ApiConsumer = require('../utils/api-consumer');
+const {GoogleMapsKey} = require('../utils/api-key');
 const SphericalMercator = require('sphericalmercator');
 const geolib = require('geolib');
 const merc = new SphericalMercator({size:256});
 const Storage = require('../../storage');
 const PRECISION = 7; // 6 or 5 is probably safe
-const key = process.env.GOOGLE_MAPS_KEY;
 
 var storage;
 
@@ -31,8 +31,10 @@ const getStorage = function() {
 
 const baseUrl = 'https://maps.googleapis.com/maps/api/staticmap';
 
+
 // We will rely on the default maxsize limit of the cache
 const GoogleMaps = new ApiConsumer('GoogleMaps', baseUrl, {cache: {ttl: Infinity}});
+ApiConsumer.setRequiredAPIKey(GoogleMaps, GoogleMapsKey);
 GoogleMaps._coordsAt = function(x, y, map) {
     x = Math.ceil(x / map.scale);
     y = Math.ceil(y / map.scale);
@@ -65,7 +67,7 @@ GoogleMaps._getGoogleParams = function(options, precisionLimit=PRECISION) {
         size: `${options.width}x${options.height}`,
         scale: options.scale,
         center: `${centerLat},${centerLon}`,
-        key: key,
+        key: this.apiKey.value,
         zoom: options.zoom || 12,
         maptype: options.mapType
     };
@@ -330,14 +332,6 @@ GoogleMaps.minLatitude = function() {
         .then(map => map.min.lat);
 };
 
-GoogleMaps.isSupported = () => {
-    if(!key){
-        /* eslint-disable no-console*/
-        console.error('GOOGLE_MAPS_KEY is missing.');
-        /* eslint-enable no-console*/
-    }
-    return !!key;
-};
 // Map of argument name to old field name
 GoogleMaps.COMPATIBILITY = {
     path: 'staticmap',

--- a/src/server/services/procedures/google-maps/google-maps.js
+++ b/src/server/services/procedures/google-maps/google-maps.js
@@ -34,7 +34,7 @@ const baseUrl = 'https://maps.googleapis.com/maps/api/staticmap';
 
 // We will rely on the default maxsize limit of the cache
 const GoogleMaps = new ApiConsumer('GoogleMaps', baseUrl, {cache: {ttl: Infinity}});
-ApiConsumer.setRequiredAPIKey(GoogleMaps, GoogleMapsKey);
+ApiConsumer.setRequiredApiKey(GoogleMaps, GoogleMapsKey);
 GoogleMaps._coordsAt = function(x, y, map) {
     x = Math.ceil(x / map.scale);
     y = Math.ceil(y / map.scale);

--- a/src/server/services/procedures/google-streetview/google-streetview.js
+++ b/src/server/services/procedures/google-streetview/google-streetview.js
@@ -10,7 +10,7 @@
 const {GoogleMapsKey} = require('../utils/api-key');
 const ApiConsumer = require('../utils/api-consumer');
 const GoogleStreetView = new ApiConsumer('GoogleStreetView', 'https://maps.googleapis.com/maps/api/streetview',{cache: {ttl: 7*24*60*60}});
-ApiConsumer.setRequiredAPIKey(GoogleStreetView, GoogleMapsKey);
+ApiConsumer.setRequiredApiKey(GoogleStreetView, GoogleMapsKey);
 
 /**
  * Get Street View image of a location using coordinates

--- a/src/server/services/procedures/google-streetview/google-streetview.js
+++ b/src/server/services/procedures/google-streetview/google-streetview.js
@@ -7,20 +7,10 @@
  */
 'use strict';
 
-var key = process.env.GOOGLE_MAPS_KEY;
-
+const {GoogleMapsKey} = require('../utils/api-key');
 const ApiConsumer = require('../utils/api-consumer');
 const GoogleStreetView = new ApiConsumer('GoogleStreetView', 'https://maps.googleapis.com/maps/api/streetview',{cache: {ttl: 7*24*60*60}});
-
-GoogleStreetView.isSupported = () => {
-    if(!key){
-        /* eslint-disable no-console*/
-        console.error('GOOGLE_MAPS_KEY is missing.');
-        /* eslint-enable no-console*/
-    }
-    return !!key;
-};
-
+ApiConsumer.setRequiredAPIKey(GoogleStreetView, GoogleMapsKey);
 
 /**
  * Get Street View image of a location using coordinates
@@ -35,6 +25,7 @@ GoogleStreetView.isSupported = () => {
  * @deprecated
  */
 GoogleStreetView.getViewFromLatLong = function(latitude, longitude, width, height, fieldofview, heading, pitch) {
+    const key = this.apiKey.value;
     return this._sendImage({queryString: `?size=${width}x${height}&location=${latitude},${longitude}&fov=${fieldofview}&heading=${heading}&pitch=${pitch}&key=${key}`, method: 'GET'});
 };
 
@@ -50,6 +41,7 @@ GoogleStreetView.getViewFromLatLong = function(latitude, longitude, width, heigh
  * @returns {Image} Image of requested location with specified size and orientation
  */
 GoogleStreetView.getView = function(latitude, longitude, width, height, fieldofview, heading, pitch) {
+    const key = this.apiKey.value;
     return this._sendImage({queryString: `?size=${width}x${height}&location=${latitude},${longitude}&fov=${fieldofview}&heading=${heading}&pitch=${pitch}&key=${key}`, method: 'GET'});
 };
 
@@ -65,6 +57,7 @@ GoogleStreetView.getView = function(latitude, longitude, width, height, fieldofv
  * @returns {Image} Image of requested location with specified size and orientation
  */
 GoogleStreetView.getViewFromAddress = function(location, width, height, fieldofview, heading, pitch) {
+    const key = this.apiKey.value;
     return this._sendImage({queryString: `?size=${width}x${height}&location=${location}&fov=${fieldofview}&heading=${heading}&pitch=${pitch}&key=${key}`, method: 'GET'});
 };
 
@@ -82,6 +75,7 @@ GoogleStreetView.getViewFromAddress = function(location, width, height, fieldofv
  * @returns {Object} Metadata infromation about the requested Street View.
  */
 GoogleStreetView.getInfo = function(latitude, longitude, width, height, fieldofview, heading, pitch) {
+    const key = this.apiKey.value;
     const queryOpts = {
         path: '/metadata',
         queryString: `?location=${latitude},${longitude}&fov=${fieldofview}&heading=${heading}&pitch=${pitch}&key=${key}`
@@ -102,6 +96,7 @@ GoogleStreetView.getInfo = function(latitude, longitude, width, height, fieldofv
  * @returns {Object} Metadata infromation about the requested Street View.
  */
 GoogleStreetView.getInfoFromAddress = function(location, width, height, fieldofview, heading, pitch) {
+    const key = this.apiKey.value;
     const queryOpts = {
         path: '/metadata',
         queryString: `?location=${location}&fov=${fieldofview}&heading=${heading}&pitch=${pitch}&key=${key}`
@@ -120,6 +115,7 @@ GoogleStreetView.getInfoFromAddress = function(location, width, height, fieldofv
  * @returns {Boolean}
  */
 GoogleStreetView.isAvailable = function(latitude, longitude, fieldofview, heading, pitch) {
+    const key = this.apiKey.value;
     const queryOpts = {
         path: '/metadata',
         queryString: `?location=${latitude},${longitude}&fov=${fieldofview}&heading=${heading}&pitch=${pitch}&key=${key}`
@@ -137,6 +133,7 @@ GoogleStreetView.isAvailable = function(latitude, longitude, fieldofview, headin
  * @returns {Boolean}
  */
 GoogleStreetView.isAvailableFromAddress = function(location, fieldofview, heading, pitch) {
+    const key = this.apiKey.value;
     const queryOpts = {
         path: '/metadata',
         queryString: `?location=${location}&fov=${fieldofview}&heading=${heading}&pitch=${pitch}&key=${key}`

--- a/src/server/services/procedures/movie-db/movie-db.js
+++ b/src/server/services/procedures/movie-db/movie-db.js
@@ -15,7 +15,7 @@ const ApiConsumer = require('../utils/api-consumer');
 const baseUrl = 'https://image.tmdb.org/t/p/w500';
 const MovieDB = new ApiConsumer('MovieDB', baseUrl);
 const {TheMovieDBKey} = require('../utils/api-key');
-ApiConsumer.setRequiredAPIKey(MovieDB, TheMovieDBKey);
+ApiConsumer.setRequiredApiKey(MovieDB, TheMovieDBKey);
 MovieDB._getApiClient = function() {
     return new ApiClient(this.apiKey.value);
 };

--- a/src/server/services/procedures/nasa/nasa.js
+++ b/src/server/services/procedures/nasa/nasa.js
@@ -15,7 +15,7 @@ const MARS_URL = 'http://marsweather.ingenology.com/v1/latest/';
 
 const NASA = {};
 NASA.serviceName = 'NASA';
-utils.setRequiredAPIKey(NASA, NASAKey);
+utils.setRequiredApiKey(NASA, NASAKey);
 
 NASA._fetchApod = async function() {
     const { data: body } = await axios.get(this._apodUrl());

--- a/src/server/services/procedures/paralleldots/paralleldots.js
+++ b/src/server/services/procedures/paralleldots/paralleldots.js
@@ -11,7 +11,7 @@
 const ApiConsumer = require('../utils/api-consumer');
 const {ParallelDotsKey} = require('../utils/api-key');
 const ParallelDots = new ApiConsumer('ParallelDots', 'https://apis.paralleldots.com/v4',{cache: {ttl: 5*60}});
-ApiConsumer.setRequiredAPIKey(ParallelDots, ParallelDotsKey);
+ApiConsumer.setRequiredApiKey(ParallelDots, ParallelDotsKey);
 
 const toLowerCaseKeys = object => {
     const result = {};

--- a/src/server/services/procedures/paralleldots/paralleldots.js
+++ b/src/server/services/procedures/paralleldots/paralleldots.js
@@ -9,8 +9,9 @@
  */
 
 const ApiConsumer = require('../utils/api-consumer');
+const {ParallelDotsKey} = require('../utils/api-key');
 const ParallelDots = new ApiConsumer('ParallelDots', 'https://apis.paralleldots.com/v4',{cache: {ttl: 5*60}});
-const key = process.env.PARALLELDOTS_KEY;
+ApiConsumer.setRequiredAPIKey(ParallelDots, ParallelDotsKey);
 
 const toLowerCaseKeys = object => {
     const result = {};
@@ -23,7 +24,7 @@ const toLowerCaseKeys = object => {
 };
 
 ParallelDots._parallelDotsRequest = function(path, text){
-    let body = `api_key=${key}&text=${encodeURI(text)}`;
+    let body = `api_key=${this.apiKey.value}&text=${encodeURI(text)}`;
     return this._sendAnswer({
         path: path,
         method: 'POST',
@@ -49,7 +50,7 @@ ParallelDots.getSentiment = async function(text) {
  * @param {String} text2 Long text (more than 2 words)
  */
 ParallelDots.getSimilarity = async function(text1, text2) {
-    const body = `api_key=${key}&text_1=${encodeURI(text1)}&text_2=${encodeURI(text2)}`;
+    const body = `api_key=${this.apiKey.value}&text_1=${encodeURI(text1)}&text_2=${encodeURI(text2)}`;
     const result = await this._sendAnswer({
         path: '/similarity', method: 'POST',
         headers: {'Content-Type' : 'application/x-www-form-urlencoded'},
@@ -128,16 +129,6 @@ ParallelDots.getIntent = async function(text) {
  */
 ParallelDots.getAbuse = function(text) {
     return this._parallelDotsRequest('/abuse', text);
-};
-
-
-ParallelDots.isSupported = () => {
-    if(!key){
-        /* eslint-disable no-console*/
-        console.error('PARALLELDOTS_KEY is missing.');
-        /* eslint-enable no-console*/
-    }
-    return !!key;
 };
 
 module.exports = ParallelDots;

--- a/src/server/services/procedures/pixabay/pixabay.js
+++ b/src/server/services/procedures/pixabay/pixabay.js
@@ -6,7 +6,8 @@
 
 const ApiConsumer = require('../utils/api-consumer');
 const pixabay = new ApiConsumer('Pixabay', 'https://pixabay.com/api/?');
-const KEY = process.env.PIXABAY;
+const {PixabayKey} = require('../utils/api-key');
+ApiConsumer.setRequiredAPIKey(pixabay, PixabayKey);
 const rpcUtils = require('../utils');
 
 function parserFnGen(maxHeight) {
@@ -29,7 +30,7 @@ function parserFnGen(maxHeight) {
     };
 }
 
-function encodeQueryOptions(keywords, type, minHeight, self) {
+pixabay._encodeQueryOptions = function(keywords, type, minHeight, self) {
     if (self === 'searchAll') {
         type = 'all';
     } else if (self === 'searchPhoto') {
@@ -39,14 +40,14 @@ function encodeQueryOptions(keywords, type, minHeight, self) {
     }
     return {
         queryString: rpcUtils.encodeQueryData({
-            key: KEY,
+            key: this.apiKey.value,
             q: encodeURIComponent(keywords),
             image_type: type,
             safesearch: true,
             min_height: (minHeight || 0)
         })
     };
-}
+};
 
 
 /**
@@ -56,7 +57,7 @@ function encodeQueryOptions(keywords, type, minHeight, self) {
  * @param {Number=} minHeight Restrict query to images larger than "minHeight"
  */
 pixabay.searchPhoto = function (keywords, maxHeight, minHeight) {
-    return this._sendStruct(encodeQueryOptions(keywords, null, minHeight, 'searchPhoto'), parserFnGen(maxHeight));
+    return this._sendStruct(this._encodeQueryOptions(keywords, null, minHeight, 'searchPhoto'), parserFnGen(maxHeight));
 };
 
 /**
@@ -66,7 +67,7 @@ pixabay.searchPhoto = function (keywords, maxHeight, minHeight) {
  * @param {Number=} minHeight Restrict query to images larger than "minHeight"
  */
 pixabay.searchIllustration = function (keywords, maxHeight, minHeight) {
-    return this._sendStruct(encodeQueryOptions(keywords, null, minHeight, 'searchIllustration'), parserFnGen(maxHeight));
+    return this._sendStruct(this._encodeQueryOptions(keywords, null, minHeight, 'searchIllustration'), parserFnGen(maxHeight));
 };
 
 /**
@@ -76,7 +77,7 @@ pixabay.searchIllustration = function (keywords, maxHeight, minHeight) {
  * @param {Number=} minHeight Restrict query to images larger than "minHeight"
  */
 pixabay.searchAll = function (keywords, maxHeight, minHeight) {
-    return this._sendStruct(encodeQueryOptions(keywords, null, minHeight, 'searchAll'), parserFnGen(maxHeight));
+    return this._sendStruct(this._encodeQueryOptions(keywords, null, minHeight, 'searchAll'), parserFnGen(maxHeight));
 };
 
 /**
@@ -85,15 +86,6 @@ pixabay.searchAll = function (keywords, maxHeight, minHeight) {
  */
 pixabay.getImage = function(url){
     return this._sendImage({url});
-};
-
-pixabay.isSupported = () => {
-    if(!process.env.PIXABAY) {
-        /* eslint-disable no-console*/
-        console.log('Warning: environment variable PIXABAY not defined, Pixabay RPC will not work.');
-        /* eslint-enable no-console*/
-    }
-    return !!process.env.PIXABAY;
 };
 
 module.exports = pixabay;

--- a/src/server/services/procedures/pixabay/pixabay.js
+++ b/src/server/services/procedures/pixabay/pixabay.js
@@ -7,7 +7,7 @@
 const ApiConsumer = require('../utils/api-consumer');
 const pixabay = new ApiConsumer('Pixabay', 'https://pixabay.com/api/?');
 const {PixabayKey} = require('../utils/api-key');
-ApiConsumer.setRequiredAPIKey(pixabay, PixabayKey);
+ApiConsumer.setRequiredApiKey(pixabay, PixabayKey);
 const rpcUtils = require('../utils');
 
 function parserFnGen(maxHeight) {

--- a/src/server/services/procedures/traffic/traffic.js
+++ b/src/server/services/procedures/traffic/traffic.js
@@ -7,7 +7,8 @@
 'use strict';
 
 const logger = require('../utils/logger')('traffic');
-const API_KEY = process.env.BING_TRAFFIC_KEY;
+const {BingMapsKey} = require('../utils/api-key');
+const utils = require('../utils');
 const request = require('request');
 const baseUrl = 'http://dev.virtualearth.net/REST/v1/Traffic/Incidents/';
 let pendingEventsFor = {};
@@ -35,13 +36,13 @@ var sendNext = function(socket) {
 };
 
 const BingTraffic = {};
-
+utils.setRequiredAPIKey(BingTraffic, BingMapsKey);
 BingTraffic.search = function(westLongitude, northLatitude, eastLongitude, southLatitude) {
 
     // for bounding box
     var response = this.response,
         url = baseUrl + southLatitude + ',' + westLongitude + ',' + northLatitude +
-            ',' + eastLongitude + '?key=' + API_KEY;
+            ',' + eastLongitude + '?key=' + this.apiKey.value;
 
     logger.trace(`Requesting traffic accidents in ${westLongitude},${northLatitude},${eastLongitude},${southLatitude}`);
     request(url, (err, res, body) => {
@@ -99,13 +100,6 @@ BingTraffic.COMPATIBILITY = {
         eastLongitude: 'eastLng',
         westLongitude: 'westLng'
     }
-};
-
-BingTraffic.isSupported = function() {
-    if (!API_KEY) {
-        logger.trace('Env variable BING_TRAFFIC_KEY is not set thus the traffic service is disabled.');
-    }
-    return !!API_KEY;
 };
 
 module.exports = BingTraffic;

--- a/src/server/services/procedures/traffic/traffic.js
+++ b/src/server/services/procedures/traffic/traffic.js
@@ -36,7 +36,7 @@ var sendNext = function(socket) {
 };
 
 const BingTraffic = {};
-utils.setRequiredAPIKey(BingTraffic, BingMapsKey);
+utils.setRequiredApiKey(BingTraffic, BingMapsKey);
 BingTraffic.search = function(westLongitude, northLatitude, eastLongitude, southLatitude) {
 
     // for bounding box

--- a/src/server/services/procedures/translation/translation.js
+++ b/src/server/services/procedures/translation/translation.js
@@ -7,9 +7,10 @@
  * @category Language
  */
 
+const {AzureTranslationKey} = require('../utils/api-key');
 const ApiConsumer = require('../utils/api-consumer');
 const TranslationConsumer = new ApiConsumer('Translation', 'https://api.cognitive.microsofttranslator.com/',{cache: {ttl: 12 * 60 * 60}});
-const key = process.env.AZURE_TRANSLATION_KEY;
+ApiConsumer.setRequiredAPIKey(TranslationConsumer, AzureTranslationKey);
 
 /**
  * Generates a GUID-like string
@@ -44,7 +45,7 @@ TranslationConsumer.translate = function(text, from, to) {
         method: 'POST',
         headers: {
             'Content-Type' : 'application/json',
-            'Ocp-Apim-Subscription-Key' : key,
+            'Ocp-Apim-Subscription-Key' : this.apiKey.value,
             'X-ClientTraceId' : guid},
         body: body}, '.translations .text[0]')
         .catch(err => {
@@ -75,7 +76,7 @@ TranslationConsumer.detectLanguage = function(text) {
         method: 'POST',
         headers: {
             'Content-Type' : 'application/json',
-            'Ocp-Apim-Subscription-Key' : key,
+            'Ocp-Apim-Subscription-Key' : this.apiKey.value,
             'X-ClientTraceId' : guid},
         body: body}, '.language[0]')
         .catch(err => {
@@ -93,21 +94,10 @@ TranslationConsumer.getSupportedLanguages = function() {
         queryString: '?api-version=3.0&scope=translation',
         headers: {
             'Content-Type' : 'application/json',
-            'Ocp-Apim-Subscription-Key' : key}}, '.translation')
+            'Ocp-Apim-Subscription-Key' : this.apiKey.value}}, '.translation')
         .catch(err => {
             throw err;
         });
-};
-
-
-
-TranslationConsumer.isSupported = () => {
-    if(!key){
-        /* eslint-disable no-console*/
-        console.error('AZURE_TRANSLATION_KEY is missing.');
-        /* eslint-enable no-console*/
-    }
-    return !!key;
 };
 
 module.exports = TranslationConsumer;

--- a/src/server/services/procedures/translation/translation.js
+++ b/src/server/services/procedures/translation/translation.js
@@ -10,7 +10,7 @@
 const {AzureTranslationKey} = require('../utils/api-key');
 const ApiConsumer = require('../utils/api-consumer');
 const TranslationConsumer = new ApiConsumer('Translation', 'https://api.cognitive.microsofttranslator.com/',{cache: {ttl: 12 * 60 * 60}});
-ApiConsumer.setRequiredAPIKey(TranslationConsumer, AzureTranslationKey);
+ApiConsumer.setRequiredApiKey(TranslationConsumer, AzureTranslationKey);
 
 /**
  * Generates a GUID-like string

--- a/src/server/services/procedures/twitter/twitter.js
+++ b/src/server/services/procedures/twitter/twitter.js
@@ -8,17 +8,14 @@
 // This will use the Twitter API to allow the client to execute certain Twitter functions within NetsBlox
 
 'use strict';
+const {TwitterKey} = require('../utils/api-key');
 const ApiConsumer = require('../utils/api-consumer');
-var KEY = process.env.TWITTER_BEARER_TOKEN;
-
-// make sure key starts with bearer
-if (KEY && !KEY.startsWith('Bearer ')) KEY = 'Bearer ' + KEY;
-
 const TwitterConsumer = new ApiConsumer('Twitter', 'https://api.twitter.com/1.1/', {
     cache: {
         ttl: 30
     }
 });
+ApiConsumer.setRequiredAPIKey(TwitterConsumer, TwitterKey);
 
 function rateCheck(response, res) {
     if (response.statusCode == 429) {
@@ -27,15 +24,6 @@ function rateCheck(response, res) {
     }
     return false;
 }
-
-TwitterConsumer.isSupported = () => {
-    if (!KEY) {
-        /* eslint-disable no-console*/
-        console.error('TWITTER_BEARER_TOKEN is missing.');
-        /* eslint-enable no-console*/
-    }
-    return KEY;
-};
 
 /**
  * Get tweets from a user
@@ -48,7 +36,7 @@ TwitterConsumer.recentTweets = function (screenName, count) {
         path: 'statuses/user_timeline.json',
         queryString: `?screen_name=${screenName}&count=${count}`,
         headers: {
-            Authorization: KEY,
+            Authorization: this.apiKey.value,
             gzip: 'true'
         }
     }).then(res => {
@@ -72,7 +60,7 @@ TwitterConsumer.followers = function (screenName) {
         path: 'users/show.json',
         queryString: `?screen_name=${screenName}`,
         headers: {
-            Authorization: KEY,
+            Authorization: this.apiKey.value,
             gzip: 'true'
         }
     }, '.followers_count').catch(err => {
@@ -93,7 +81,7 @@ TwitterConsumer.tweets = function (screenName) {
         path: 'users/show.json',
         queryString: `?screen_name=${screenName}`,
         headers: {
-            Authorization: KEY,
+            Authorization: this.apiKey.value,
             gzip: 'true'
         }
     }, '.statuses_count').catch(err => {
@@ -117,7 +105,7 @@ TwitterConsumer.search = function (keyword, count) {
         path: 'search/tweets.json',
         queryString: `?q=${encodeURI(keyword)}&count=${count}`,
         headers: {
-            Authorization: KEY,
+            Authorization: this.apiKey.value,
             gzip: 'true'
         }
     }).then(res => {
@@ -145,7 +133,7 @@ TwitterConsumer.tweetsPerDay = function (screenName) {
         path: 'statuses/user_timeline.json',
         queryString: `?screen_name=${screenName}&count=200`,
         headers: {
-            Authorization: KEY,
+            Authorization: this.apiKey.value,
             gzip: 'true'
         }
     }).then(res => {
@@ -171,7 +159,7 @@ TwitterConsumer.favorites = function (screenName, count) {
         path: 'favorites/list.json',
         queryString: `?screen_name=${screenName}&count=${count}`,
         headers: {
-            Authorization: KEY,
+            Authorization: this.apiKey.value,
             gzip: 'true'
         }
     }).then(res => {
@@ -196,7 +184,7 @@ TwitterConsumer.favoritesCount = function (screenName) {
         path: 'users/show.json',
         queryString: `?screen_name=${screenName}`,
         headers: {
-            Authorization: KEY,
+            Authorization: this.apiKey.value,
             gzip: 'true'
         }
     }, '.favourites_count').catch(err => {

--- a/src/server/services/procedures/twitter/twitter.js
+++ b/src/server/services/procedures/twitter/twitter.js
@@ -15,7 +15,7 @@ const TwitterConsumer = new ApiConsumer('Twitter', 'https://api.twitter.com/1.1/
         ttl: 30
     }
 });
-ApiConsumer.setRequiredAPIKey(TwitterConsumer, TwitterKey);
+ApiConsumer.setRequiredApiKey(TwitterConsumer, TwitterKey);
 
 function rateCheck(response, res) {
     if (response.statusCode == 429) {

--- a/src/server/services/procedures/utils/api-consumer.js
+++ b/src/server/services/procedures/utils/api-consumer.js
@@ -225,8 +225,8 @@ class ApiConsumer extends NBService {
             });
     }
 
-    static setRequiredAPIKey(service, apiKey) {
-        utils.setRequiredAPIKey(service, apiKey);
+    static setRequiredApiKey(service, apiKey) {
+        utils.setRequiredApiKey(service, apiKey);
     }
 }
 

--- a/src/server/services/procedures/utils/api-consumer.js
+++ b/src/server/services/procedures/utils/api-consumer.js
@@ -7,6 +7,8 @@ const NBService = require('./service.js'),
     request = require('request'),
     rp = require('request-promise');
 
+const utils = require('./index');
+
 class ApiConsumer extends NBService {
     constructor(name, baseUrl, opts) {
         opts = _.merge({
@@ -221,6 +223,10 @@ class ApiConsumer extends NBService {
                 this._logger.trace('got response');
                 this._logger.trace(this.__queryJson(res,selector));
             });
+    }
+
+    static setRequiredAPIKey(service, apiKey) {
+        utils.setRequiredAPIKey(service, apiKey);
     }
 }
 

--- a/src/server/services/procedures/utils/api-key.js
+++ b/src/server/services/procedures/utils/api-key.js
@@ -19,4 +19,48 @@ class ApiKey {
     }
 }
 
-module.exports = ApiKey;
+module.exports.GoogleMapsKey = new ApiKey(
+    'Google Maps',
+    'https://developers.google.com/maps/documentation/maps-static/get-api-key#get_key'
+);
+module.exports.AirNowKey = new ApiKey(
+    'Air Now',
+    'https://docs.airnowapi.org/'
+);
+module.exports.ParallelDotsKey = new ApiKey(
+    'ParallelDots',
+    'https://www.paralleldots.com/text-analysis-apis',
+    'PARALLELDOTS_KEY'
+);
+module.exports.BingMapsKey = new ApiKey(
+    'Bing Maps',
+    'https://docs.microsoft.com/en-us/bingmaps/getting-started/bing-maps-dev-center-help/getting-a-bing-maps-key',
+    'BING_TRAFFIC_KEY'
+);
+module.exports.NASAKey = new ApiKey(
+    'NASA',
+    'https://api.nasa.gov/'
+);
+module.exports.TheMovieDBKey = new ApiKey(
+    'The Movie Database',
+    'https://developers.themoviedb.org/3/getting-started/introduction',
+    'TMDB_API_KEY'
+);
+module.exports.OpenWeatherMapKey = new ApiKey(
+    'Open Weather Map',
+    'https://developers.themoviedb.org/3/getting-started/introduction',
+);
+module.exports.AzureTranslationKey = new ApiKey(
+    'Azure Translation',
+    'https://azure.microsoft.com/en-us/services/cognitive-services/translator-text-api/'
+);
+module.exports.PixabayKey = new ApiKey(
+    'Pixabay',
+    'https://pixabay.com/api/docs/#api_key',
+    'PIXABAY'
+);
+module.exports.TwitterKey = new ApiKey(
+    'Twitter',
+    'https://developer.twitter.com/en/docs/basics/authentication/oauth-2-0',
+    'TWITTER_BEARER_TOKEN'
+);

--- a/src/server/services/procedures/utils/index.js
+++ b/src/server/services/procedures/utils/index.js
@@ -104,6 +104,18 @@ const isValidServiceName = name => {
     return /^[a-z0-9-]+$/i.test(name);
 };
 
+const setRequiredAPIKey = (service, apiKey) => {
+    service.apiKey = apiKey;
+    service.isSupported = function() {
+        if(!this.apiKey.value){
+            /* eslint-disable no-console*/
+            console.error(this.apiKey.envVar + ' is missing.');
+            /* eslint-enable no-console*/
+        }
+        return !!this.apiKey.value;
+    };
+};
+
 module.exports = {
     getRoleNames,
     getRoleIds,
@@ -113,4 +125,5 @@ module.exports = {
     collectStream,
     jsonToSnapList,
     isValidServiceName,
+    setRequiredAPIKey,
 };

--- a/src/server/services/procedures/utils/index.js
+++ b/src/server/services/procedures/utils/index.js
@@ -104,7 +104,7 @@ const isValidServiceName = name => {
     return /^[a-z0-9-]+$/i.test(name);
 };
 
-const setRequiredAPIKey = (service, apiKey) => {
+const setRequiredApiKey = (service, apiKey) => {
     service.apiKey = apiKey;
     service.isSupported = function() {
         if(!this.apiKey.value){
@@ -125,5 +125,5 @@ module.exports = {
     collectStream,
     jsonToSnapList,
     isValidServiceName,
-    setRequiredAPIKey,
+    setRequiredApiKey,
 };

--- a/src/server/services/procedures/weather/weather.js
+++ b/src/server/services/procedures/weather/weather.js
@@ -17,7 +17,7 @@ const MAX_DISTANCE = +process.env.WEATHER_MAX_DISTANCE || Infinity;  // miles
 const geolib = require('geolib');
 
 const weather = new ApiConsumer('Weather', 'http://api.openweathermap.org/data/2.5/weather', {cache: {ttl: 60}});
-ApiConsumer.setRequiredAPIKey(weather, OpenWeatherMapKey);
+ApiConsumer.setRequiredApiKey(weather, OpenWeatherMapKey);
 
 const isWithinMaxDistance = function(result, lat, lng) {
     var distance = geolib.getDistance(

--- a/src/server/services/procedures/weather/weather.js
+++ b/src/server/services/procedures/weather/weather.js
@@ -11,12 +11,13 @@
 
 const logger = require('../utils/logger')('weather');
 const tuc = require('temp-units-conv');
+const {OpenWeatherMapKey} = require('../utils/api-key');
 const ApiConsumer = require('../utils/api-consumer');
-const API_KEY = process.env.OPEN_WEATHER_MAP_KEY;
 const MAX_DISTANCE = +process.env.WEATHER_MAX_DISTANCE || Infinity;  // miles
 const geolib = require('geolib');
 
 const weather = new ApiConsumer('Weather', 'http://api.openweathermap.org/data/2.5/weather', {cache: {ttl: 60}});
+ApiConsumer.setRequiredAPIKey(weather, OpenWeatherMapKey);
 
 const isWithinMaxDistance = function(result, lat, lng) {
     var distance = geolib.getDistance(
@@ -31,8 +32,8 @@ const isWithinMaxDistance = function(result, lat, lng) {
     return distance < MAX_DISTANCE;
 };
 
-const queryString = function(latitude, longitude) {
-    return `APPID=${API_KEY}&lat=${latitude}&lon=${longitude}`;
+weather._queryString = function(latitude, longitude) {
+    return `APPID=${this.apiKey.value}&lat=${latitude}&lon=${longitude}`;
 };
 
 /**
@@ -41,7 +42,7 @@ const queryString = function(latitude, longitude) {
  * @param {Longitude} longitude
  */
 weather.temperature = function(latitude, longitude){
-    return this._requestData({queryString: queryString(latitude, longitude)})
+    return this._requestData({queryString: this._queryString(latitude, longitude)})
         .then(body => {
             var temp = 'unknown';
             if (body.main && isWithinMaxDistance(body, latitude, longitude)) {
@@ -69,7 +70,7 @@ weather.temp = function(latitude, longitude) {
  * @param {Longitude} longitude
  */
 weather.humidity = function(latitude, longitude){
-    return this._requestData({queryString: queryString(latitude, longitude)})
+    return this._requestData({queryString: this._queryString(latitude, longitude)})
         .then(body => {
             var humidity = 'unknown';
             if (isWithinMaxDistance(body, latitude, longitude)) {
@@ -85,7 +86,7 @@ weather.humidity = function(latitude, longitude){
  * @param {Longitude} longitude
  */
 weather.description = function(latitude, longitude){
-    return this._requestData({queryString: queryString(latitude, longitude)})
+    return this._requestData({queryString: this._queryString(latitude, longitude)})
         .then(body => {
             var description = 'unknown';
             if (isWithinMaxDistance(body, latitude, longitude)) {
@@ -101,7 +102,7 @@ weather.description = function(latitude, longitude){
  * @param {Longitude} longitude
  */
 weather.windSpeed = function(latitude, longitude){
-    return this._requestData({queryString: queryString(latitude, longitude)})
+    return this._requestData({queryString: this._queryString(latitude, longitude)})
         .then(body => {
             var speed = 'unknown';
             if (isWithinMaxDistance(body, latitude, longitude)) {
@@ -117,7 +118,7 @@ weather.windSpeed = function(latitude, longitude){
  * @param {Longitude} longitude
  */
 weather.windAngle = function(latitude, longitude){
-    return this._requestData({queryString: queryString(latitude, longitude)})
+    return this._requestData({queryString: this._queryString(latitude, longitude)})
         .then(body => {
             var deg = 'unknown';
             if (isWithinMaxDistance(body, latitude, longitude)) {
@@ -133,7 +134,7 @@ weather.windAngle = function(latitude, longitude){
  * @param {Longitude} longitude
  */
 weather.icon = function(latitude, longitude){
-    return this._requestData({queryString: queryString(latitude, longitude)})
+    return this._requestData({queryString: this._queryString(latitude, longitude)})
         .then(body => {
             // Return sunny if unknown
             var iconName = '01d.png';


### PR DESCRIPTION
This updates the use of API keys in the services to be able to be overridden. This also standardizes some of the error messages for unsupported services (by using the helper method `setRequiredApiKey`) and highlights some of the inconsistencies with the environment variable naming for API keys.

Also, this updates the Google geocoding API to use the same key as GoogleMaps and GoogleStreetView.