### PR TITLE
Update data service defaults. Closes #2648

### DIFF
--- a/src/server/services/procedures/service-creation/blocks/getColumns.tpl
+++ b/src/server/services/procedures/service-creation/blocks/getColumns.tpl
@@ -1,0 +1,42 @@
+<context id="1">
+  <inputs>
+    <input>row</input>
+  </inputs>
+  <variables/>
+  <script>
+    <block s="doReport">
+      <block s="reportNewList">
+        <list>
+          <block s="reportListItem">
+            <l>1</l>
+            <block var="row"/>
+          </block>
+          <block s="reportListItem">
+            <l><%= column %></l>
+            <block var="row"/>
+          </block>
+        </list>
+      </block>
+    </block>
+  </script>
+  <receiver>
+    <sprite name="Sprite" idx="1" x="0" y="0" heading="90" scale="1" rotation="1" draggable="true" costume="0" color="80,80,80" pen="tip" id="17">
+      <costumes>
+        <list id="18"/>
+      </costumes>
+      <sounds>
+        <list id="19"/>
+      </sounds>
+      <variables/>
+      <blocks/>
+      <scripts/>
+    </sprite>
+  </receiver>
+  <context id="22">
+    <inputs/>
+    <variables/>
+    <receiver>
+      <ref id="17"/>
+    </receiver>
+  </context>
+</context>

--- a/src/server/services/procedures/service-creation/blocks/getTable.tpl
+++ b/src/server/services/procedures/service-creation/blocks/getTable.tpl
@@ -1,0 +1,47 @@
+<context id="1">
+  <inputs>
+    <input>data</input>
+  </inputs>
+  <variables/>
+  <script>
+    <block s="doDeclareVariables">
+      <list>
+        <l>field names</l>
+      </list>
+    </block>
+    <block s="doSetVar">
+      <l>field names</l>
+      <block s="reportNewList">
+        <list>
+          <%= fields.map(field => `<l>${field}</l>`) %>
+        </list>
+      </block>
+    </block>
+    <block s="doReport">
+      <block s="reportCONS">
+        <block var="field names"/>
+        <block var="data"/>
+      </block>
+    </block>
+  </script>
+  <receiver>
+    <sprite name="Sprite" idx="1" x="0" y="0" heading="90" scale="1" rotation="1" draggable="true" costume="0" color="80,80,80" pen="tip" id="22">
+      <costumes>
+        <list id="23"/>
+      </costumes>
+      <sounds>
+        <list id="24"/>
+      </sounds>
+      <variables/>
+      <blocks/>
+      <scripts/>
+    </sprite>
+  </receiver>
+  <context id="27">
+    <inputs/>
+    <variables/>
+    <receiver>
+      <ref id="22"/>
+    </receiver>
+  </context>
+</context>

--- a/src/server/services/procedures/service-creation/blocks/getValue.tpl
+++ b/src/server/services/procedures/service-creation/blocks/getValue.tpl
@@ -1,0 +1,127 @@
+<context id="1">
+  <inputs>
+    <input><%= fields[0] %></input>
+    <input>column name</input>
+    <input><%= dataVariable %></input>
+  </inputs>
+  <variables/>
+  <script>
+    <block s="doDeclareVariables">
+      <list>
+        <l>field names</l>
+        <l>row index</l>
+        <l>column</l>
+        <l>row</l>
+      </list>
+    </block>
+    <block s="doSetVar">
+      <l>field names</l>
+      <block s="reportNewList">
+        <list>
+          <%= fields.map(field => `<l>${field}</l>`) %>
+        </list>
+      </block>
+    </block>
+    <block s="doSetVar">
+      <l>row index</l>
+      <l>1</l>
+    </block>
+    <block s="doRepeat">
+      <block s="reportListLength">
+        <block var="<%= dataVariable %>"/>
+      </block>
+      <script>
+        <block s="doSetVar">
+          <l>row</l>
+          <block s="reportListItem">
+            <block var="row index"/>
+            <block var="<%= dataVariable %>"/>
+          </block>
+        </block>
+        <block s="doIf">
+          <block s="reportEquals">
+            <block s="reportListItem">
+              <l>1</l>
+              <block var="row"/>
+            </block>
+            <block var="<%= fields[0] %>"/>
+          </block>
+          <script>
+            <block s="doSetVar">
+              <l>column</l>
+              <l>1</l>
+            </block>
+            <block s="doRepeat">
+              <block s="reportListLength">
+                <block var="field names"/>
+              </block>
+              <script>
+                <block s="doIf">
+                  <block s="reportEquals">
+                    <block s="reportListItem">
+                      <block var="column"/>
+                      <block var="field names"/>
+                    </block>
+                    <block var="column name"/>
+                  </block>
+                  <script>
+                    <block s="doReport">
+                      <block s="reportListItem">
+                        <block var="column"/>
+                        <block var="row"/>
+                      </block>
+                    </block>
+                  </script>
+                </block>
+                <block s="doChangeVar">
+                  <l>column</l>
+                  <l>1</l>
+                </block>
+              </script>
+            </block>
+            <block s="doReport">
+              <block s="reportJoinWords">
+                <list>
+                  <l>Column not found: </l>
+                  <block var="column name"/>
+                </list>
+              </block>
+            </block>
+          </script>
+        </block>
+        <block s="doChangeVar">
+          <l>row index</l>
+          <l>1</l>
+        </block>
+      </script>
+    </block>
+    <block s="doReport">
+      <block s="reportJoinWords">
+        <list>
+          <l>Could not find "<%= fields[0] %>" with value: </l>
+          <block var="<%= fields[0] %>"/>
+        </list>
+      </block>
+    </block>
+  </script>
+  <receiver>
+    <sprite name="Sprite" idx="1" x="0" y="0" heading="90" scale="1" rotation="1" draggable="true" costume="0" color="80,80,80" pen="tip" id="89">
+      <costumes>
+        <list id="90"/>
+      </costumes>
+      <sounds>
+        <list id="91"/>
+      </sounds>
+      <variables/>
+      <blocks/>
+      <scripts/>
+    </sprite>
+  </receiver>
+  <context id="94">
+    <inputs/>
+    <variables/>
+    <receiver>
+      <ref id="89"/>
+    </receiver>
+  </context>
+</context>

--- a/src/server/services/procedures/service-creation/service-creation.js
+++ b/src/server/services/procedures/service-creation/service-creation.js
@@ -181,6 +181,14 @@ ServiceCreation.getCreateFromTableOptions = function(data) {
         rpcOptions.push(getIndexFieldRPC);
     }
 
+    if (data.length < 2000) {
+        rpcOptions.push({
+            name: 'getTable',
+            help: 'Get the entire dataset as a table',
+            code: Blocks.getTable({fields})
+        });
+    }
+
     return {
         help: `Dataset uploaded by ${this.caller.username}`,
         RPCs: rpcOptions

--- a/test/unit/server/services/procedures/service-creation.spec.js
+++ b/test/unit/server/services/procedures/service-creation.spec.js
@@ -67,7 +67,7 @@ describe('service-creation', function() {
             ]);
             const options = service.getCreateFromTableOptions(data);
             const rpcNames = options.RPCs.map(rpc => rpc.name);
-            assert(rpcNames.includes('get#Counted'));
+            assert(rpcNames.includes('get#CountedColumn'));
         });
 
         it('should support $ symbol', function() {
@@ -77,7 +77,7 @@ describe('service-creation', function() {
             ]);
             const options = service.getCreateFromTableOptions(data);
             const rpcNames = options.RPCs.map(rpc => rpc.name);
-            assert(rpcNames.includes('get$Spent'), `Could not find get$Spent: ${rpcNames.join(', ')}`);
+            assert(rpcNames.includes('get$SpentColumn'), `Could not find get$Spent: ${rpcNames.join(', ')}`);
         });
 
         it('should support % symbol', function() {
@@ -87,7 +87,7 @@ describe('service-creation', function() {
             ]);
             const options = service.getCreateFromTableOptions(data);
             const rpcNames = options.RPCs.map(rpc => rpc.name);
-            assert(rpcNames.includes('get%OfTotal'), `Could not find get%OfTotal: ${rpcNames.join(', ')}`);
+            assert(rpcNames.includes('get%OfTotalColumn'), `Could not find get%OfTotal: ${rpcNames.join(', ')}`);
         });
 
         it('should support accented characters', function() {
@@ -97,7 +97,7 @@ describe('service-creation', function() {
             ]);
             const options = service.getCreateFromTableOptions(data);
             const rpcNames = options.RPCs.map(rpc => rpc.name);
-            assert(rpcNames.includes('getÉrdösNumber'), `Could not find getÉrdösNumber: ${rpcNames.join(', ')}`);
+            assert(rpcNames.includes('getÉrdösNumberColumn'), `Could not find getÉrdösNumber: ${rpcNames.join(', ')}`);
         });
     });
 });


### PR DESCRIPTION
This adds the RPCs as described in #2648 with the exception that getting an entire column has "Column" as part of the RPC name. Otherwise, it is exactly as described in the issue.

It is worth noting that these default options are only the case when the first column is a unique identifier for the given row. There could still be some improvements to be made to the defaults when the first column is not unique...