### PR TITLE
Add BaseX service. Closes #2697

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -4,6 +4,11 @@
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
+    "@rgrove/parse-xml": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/@rgrove/parse-xml/-/parse-xml-2.0.2.tgz",
+      "integrity": "sha512-lm+PREEkFLWTSO599BrVjhUIXavhPISQGpwssquFviT2qz8eWuIz0+vDDuRqOo5sPdk5NFhqFbG9wURGHm24aQ=="
+    },
     "@types/core-js": {
       "version": "0.9.46",
       "resolved": "https://registry.npmjs.org/@types/core-js/-/core-js-0.9.46.tgz",
@@ -455,7 +460,6 @@
       "version": "0.18.0",
       "resolved": "http://registry.npmjs.org/axios/-/axios-0.18.0.tgz",
       "integrity": "sha1-MtU+SFHv3AoRmTts0AB4nXDAUQI=",
-      "dev": true,
       "requires": {
         "follow-redirects": "^1.3.0",
         "is-buffer": "^1.1.5"
@@ -3649,7 +3653,6 @@
       "version": "1.5.7",
       "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.5.7.tgz",
       "integrity": "sha512-NONJVIFiX7Z8k2WxfqBjtwqMifx7X42ORLFrOZ2LTKGj71G3C0kfdyTqGqr8fx5zSX6Foo/D95dgGWbPUiwnew==",
-      "dev": true,
       "requires": {
         "debug": "^3.1.0"
       },
@@ -3658,7 +3661,6 @@
           "version": "3.1.0",
           "resolved": "https://registry.npmjs.org/debug/-/debug-3.1.0.tgz",
           "integrity": "sha512-OX8XqP7/1a9cqkxYw2yXss15f26NKWBpDXQd0/uK/KPqdQhxbPa994hnzjcE2VqQpDslf55723cKPUOGSmMY3g==",
-          "dev": true,
           "requires": {
             "ms": "2.0.0"
           }

--- a/package.json
+++ b/package.json
@@ -29,8 +29,10 @@
   },
   "homepage": "https://github.com/NetsBlox/NetsBlox",
   "dependencies": {
+    "@rgrove/parse-xml": "^2.0.2",
     "async": "^2.6.2",
     "aws-sdk": "^2.421.0",
+    "axios": "^0.18.0",
     "body-parser": "^1.18.3",
     "cache-manager": "^2.0.0",
     "cache-manager-fs": "^1.0.7",
@@ -85,7 +87,6 @@
     "zeromq": "^6.0.0-beta.6"
   },
   "devDependencies": {
-    "axios": "^0.18.0",
     "expect": "^1.6.0",
     "istanbul": "^1.1.0-alpha.1",
     "mocha": "^5.2.0",

--- a/src/server/services/procedures/base-x/base-x.js
+++ b/src/server/services/procedures/base-x/base-x.js
@@ -1,0 +1,92 @@
+/**
+ * The BaseX Service provides access to an existing BaseX instance.
+ *
+ * @service
+ * @category Database
+ */
+const axios = require('axios');
+const parseXml = require('@rgrove/parse-xml');
+const BaseX = {};
+
+/**
+ * Evaluate an XQuery expression.
+ *
+ * @param {String} url
+ * @param {String} database
+ * @param {String} query
+ * @param {String=} username
+ * @param {String=} password
+ */
+BaseX.query = async function(url, database, query, username, password) {
+    url = `${url}/rest/${database}?query=${encodeURIComponent(query)}`;
+    return baseXRequest(url, username, password);
+};
+
+function toJsonML(xml) {
+    if (xml.type === 'text') {
+        return xml.text;
+    }
+    const name = xml.type === 'element' ? xml.name : xml.type;
+    const jsonml = [name];
+
+    const hasAttributes = Object.keys(xml.attributes || {}).length > 0;
+    if (hasAttributes) {
+        jsonml.push(xml.attributes);
+    }
+
+    const hasTextContents = xml.children.length && xml.children[0].type === 'text';
+    if (hasTextContents) {
+        jsonml.push(toJsonML(xml.children[0]));
+    } else {
+        jsonml.push(...xml.children.map(toJsonML));
+    }
+
+    return jsonml;
+}
+
+/**
+ * Execute a single database command.
+ *
+ * A list of commands can be found at http://docs.basex.org/wiki/Commands
+ *
+ * @param {String} url
+ * @param {String} command
+ * @param {String=} username
+ * @param {String=} password
+ */
+BaseX.command = function(url, command, username, password) {
+    url = `${url}/rest?command=${encodeURIComponent(command)}`;
+    return baseXRequest(url, username, password);
+};
+
+async function baseXRequest(url, username, password) {
+    const opts = {headers: {}};
+    if (username && password) {
+        const auth = Buffer.from(`${username}:${password}`).toString('base64');
+        opts.headers.Authorization = `Basic ${auth}`;
+    }
+
+    try {
+        const response = await axios.get(url, opts);
+        return parseResponse(response.data);
+    } catch (err) {
+        throw new Error(rewordError(err));
+    }
+}
+
+function rewordError(err) {
+    const {response} = err;
+    return response.data;
+}
+
+function parseResponse(data) {
+    const isXmlData = typeof data === 'string' && data.startsWith('<');
+    if (isXmlData) {
+        const xml = parseXml(data);
+        return toJsonML(xml.children[0]);
+    } else {
+        return data;
+    }
+}
+
+module.exports = BaseX;

--- a/src/server/services/procedures/base-x/base-x.js
+++ b/src/server/services/procedures/base-x/base-x.js
@@ -1,6 +1,7 @@
 /**
  * The BaseX Service provides access to an existing BaseX instance.
  *
+ * @alpha
  * @service
  * @category Database
  */

--- a/test/unit/server/services/procedures/base-x.spec.js
+++ b/test/unit/server/services/procedures/base-x.spec.js
@@ -1,0 +1,8 @@
+describe('BaseX', function() {
+    const utils = require('../../../../assets/utils');
+
+    utils.verifyRPCInterfaces('BaseX', [
+        ['query', ['url', 'database', 'query', 'username', 'password']],
+        ['command', ['url', 'command', 'username', 'password']],
+    ]);
+});


### PR DESCRIPTION
This PR adds a simple BaseX service which provides access to a BaseX instance via the `query` and `command` operations (via the [REST API](http://docs.basex.org/wiki/REST)). 

It could be useful to add support for the `commands` operation which would enable users to run entire [command scripts](http://docs.basex.org/wiki/Commands#Command_Scripts) though this is not included in this PR.