### PR TITLE
NYPL getDetails bugfix

### DIFF
--- a/src/server/services/procedures/new-york-public-library/new-york-public-library.js
+++ b/src/server/services/procedures/new-york-public-library/new-york-public-library.js
@@ -41,13 +41,17 @@ NYPL.search = async function(term, perPage = 50, page = 1) {
 };
 
 NYPL._searchForKey = function(json, key) {
-    if (json instanceof Array) {
-        for (const item of json) {
-            if (key in item) return item[key];
-        }
-        return undefined;
+    for (const item of listify(json)) {
+        if (key in item) return item[key];
     }
-    else return json[key];
+    return undefined;
+};
+NYPL._getPath = function(obj, path, default_val) {
+    for (const p of path) {
+        if (obj === undefined) return default_val;
+        obj = obj[p];
+    }
+    return obj;
 };
 
 /**
@@ -70,13 +74,8 @@ NYPL.getDetails = async function(uuid) {
     else if (dateIssued instanceof Array && dateIssued.length == 2) dateIssued = `${dateIssued[0].$}-${dateIssued[1].$}`;
     else dateIssued = 'Unknown';
 
-    let location = this._searchForKey(mods.originInfo, 'place');
-    if (location !== undefined && 'placeTerm' in location && '$' in location.placeTerm) location = location.placeTerm.$;
-    else location = 'Unknown';
-
-    let publisher = this._searchForKey(mods.originInfo, 'publisher');
-    if (publisher !== undefined && '$' in publisher) publisher = publisher.$;
-    else publisher = 'Unknown';
+    const location = this._getPath(this._searchForKey(mods.originInfo, 'place'), ['placeTerm', '$'], 'Unknown');
+    const publisher = this._getPath(this._searchForKey(mods.originInfo, 'publisher'), ['$'], 'Unknown');
 
     const genres = [];
     for (const genre of listify(mods.genre)) {


### PR DESCRIPTION
Apparently, sometimes the json returned from the NYPL `getDetails` API call will split some of their fields into disjoint objects. This PR fixes this by checking if it's split (instance of array) and doing a shallow search for the desired field. Other than that, it seems to work as-is, but I additionally added some more checks which never came up in testing but couldn't hurt to have.