### PR TITLE
added @alpha to Smithsonian and NYPL Services

### DIFF
--- a/src/server/services/procedures/new-york-public-library/new-york-public-library.js
+++ b/src/server/services/procedures/new-york-public-library/new-york-public-library.js
@@ -1,3 +1,10 @@
+/**
+ * The New York Public Library (NYPL) Service provides access to NYPL's online repository of historical items.
+ * 
+ * @alpha
+ * @service
+ * @category History
+ */
 'use strict';
 
 const ApiConsumer = require('../utils/api-consumer');
@@ -82,7 +89,7 @@ NYPL.getDetails = async function(uuid) {
  * Get the image URLs (0 or more) for the object.
  * 
  * @param {String} itemID itemID of the object
- * @returns {Array} An array of imgurls[]
+ * @returns {Array} An array of img urls
  */
 NYPL._getImageURLs = async function(itemID) {
     const res = await this._requestData({

--- a/src/server/services/procedures/smithsonian/smithsonian.js
+++ b/src/server/services/procedures/smithsonian/smithsonian.js
@@ -2,7 +2,9 @@
  * The Smithsonian Service provides access to the Smithsonan open-access EDAN database,
  * containing catalogued information on millions of historical items.
  * 
+ * @alpha
  * @service
+ * @category History
  */
 'use strict';
 


### PR DESCRIPTION
Addresses #2869. I couldn't find anywhere that the categories were defined, so I just assumed them to be strings. I gave both Smithsonian and NYPL the `History` category, as nothing pre-existing seemed to match. I think the simple term `History` matches the target audience verbage, but if it's too general (e.g. stock data could also be considered historical), we could do something like `Museum`/`MuseumData`/`MuseumContent`.