### PR TITLE
OceanData service: added optional start/end year params

### DIFF
--- a/src/server/services/procedures/ocean-data/ocean-data.js
+++ b/src/server/services/procedures/ocean-data/ocean-data.js
@@ -20,7 +20,7 @@ OceanData._data = require('./data');
  * @param {Number=} endYear latest year to include in results
  * @returns {Array} ratios - a list of oxygen isotope ratios by year
  */
-OceanData.getOxygenRatio = function(startYear = Number.NEGATIVE_INFINITY, endYear = Number.POSITIVE_INFINITY){
+OceanData.getOxygenRatio = function(startYear = -Infinity, endYear = Infinity){
     return this._data
         .filter(data => startYear <= data.year && data.year <= endYear)
         .map(data => [data.year, data.oxygenIsotopeRatio]);
@@ -33,7 +33,7 @@ OceanData.getOxygenRatio = function(startYear = Number.NEGATIVE_INFINITY, endYea
  * @param {Number=} endYear latest year to include in results
  * @returns {Array} temperatures - a list of deep ocean temperatures by year
  */
-OceanData.getDeepOceanTemp = function(startYear = Number.NEGATIVE_INFINITY, endYear = Number.POSITIVE_INFINITY){
+OceanData.getDeepOceanTemp = function(startYear = -Infinity, endYear = Infinity){
     return this._data
         .filter(data => startYear <= data.year && data.year <= endYear)
         .map(data => [data.year, data.deepOceanTemp]);
@@ -46,7 +46,7 @@ OceanData.getDeepOceanTemp = function(startYear = Number.NEGATIVE_INFINITY, endY
  * @param {Number=} endYear latest year to include in results
  * @returns {Array} temperatures - a list of surface ocean temperatures by year
  */
-OceanData.getSurfaceTemp = function(startYear = Number.NEGATIVE_INFINITY, endYear = Number.POSITIVE_INFINITY){
+OceanData.getSurfaceTemp = function(startYear = -Infinity, endYear = Infinity){
     return this._data
         .filter(data => startYear <= data.year && data.year <= endYear)
         .map(data => [data.year, data.surfaceTemp]);
@@ -59,7 +59,7 @@ OceanData.getSurfaceTemp = function(startYear = Number.NEGATIVE_INFINITY, endYea
  * @param {Number=} endYear latest year to include in results
  * @returns {Array} meters - change in sea level (in meters) by year
  */
-OceanData.getSeaLevel = function(startYear = Number.NEGATIVE_INFINITY, endYear = Number.POSITIVE_INFINITY){
+OceanData.getSeaLevel = function(startYear = -Infinity, endYear = Infinity){
     return this._data
         .filter(data => startYear <= data.year && data.year <= endYear)
         .map(data => [data.year, data.seaLevel]);

--- a/src/server/services/procedures/ocean-data/ocean-data.js
+++ b/src/server/services/procedures/ocean-data/ocean-data.js
@@ -16,40 +16,52 @@ OceanData._data = require('./data');
 /**
  * Get historical oxygen isotope ratio values by year.
  *
+ * @param {Number=} startYear earliest year to include in results
+ * @param {Number=} endYear latest year to include in results
  * @returns {Array} ratios - a list of oxygen isotope ratios by year
  */
-OceanData.getOxygenRatio = function(){
+OceanData.getOxygenRatio = function(startYear = Number.NEGATIVE_INFINITY, endYear = Number.POSITIVE_INFINITY){
     return this._data
+        .filter(data => startYear <= data.year && data.year <= endYear)
         .map(data => [data.year, data.oxygenIsotopeRatio]);
 };
 
 /**
  * Get historical deep ocean temperatures in Celsius by year.
  *
+ * @param {Number=} startYear earliest year to include in results
+ * @param {Number=} endYear latest year to include in results
  * @returns {Array} temperatures - a list of deep ocean temperatures by year
  */
-OceanData.getDeepOceanTemp = function(){
+OceanData.getDeepOceanTemp = function(startYear = Number.NEGATIVE_INFINITY, endYear = Number.POSITIVE_INFINITY){
     return this._data
+        .filter(data => startYear <= data.year && data.year <= endYear)
         .map(data => [data.year, data.deepOceanTemp]);
 };
 
 /**
  * Get historical surface ocean temperatures in Celsius by year.
  *
+ * @param {Number=} startYear earliest year to include in results
+ * @param {Number=} endYear latest year to include in results
  * @returns {Array} temperatures - a list of surface ocean temperatures by year
  */
-OceanData.getSurfaceTemp = function(){
+OceanData.getSurfaceTemp = function(startYear = Number.NEGATIVE_INFINITY, endYear = Number.POSITIVE_INFINITY){
     return this._data
+        .filter(data => startYear <= data.year && data.year <= endYear)
         .map(data => [data.year, data.surfaceTemp]);
 };
 
 /**
  * Get historical sea level in meters by year.
  *
+ * @param {Number=} startYear earliest year to include in results
+ * @param {Number=} endYear latest year to include in results
  * @returns {Array} meters - change in sea level (in meters) by year
  */
-OceanData.getSeaLevel = function(){
+OceanData.getSeaLevel = function(startYear = Number.NEGATIVE_INFINITY, endYear = Number.POSITIVE_INFINITY){
     return this._data
+        .filter(data => startYear <= data.year && data.year <= endYear)
         .map(data => [data.year, data.seaLevel]);
 };
 


### PR DESCRIPTION
Akos mentioned it would be nice to have optional start/end year params for the OceanData service. This PR adds them as numeric params which default to -inf/+inf and denote inclusive bounds. Thus, default values function identically to previous behavior. If `startYear > endYear`, empty list is returned.