### PR TITLE
added this-x-does-not-exist procedure

### DIFF
--- a/src/server/services/procedures/this-x-does-not-exist/this-x-does-not-exist.js
+++ b/src/server/services/procedures/this-x-does-not-exist/this-x-does-not-exist.js
@@ -1,0 +1,100 @@
+/**
+ * Provides access to images from various websites typically called this<X>doesnotexist.com.
+ * These are images of X generated from random noise by (typically) a GAN.
+ * 
+ * @alpha
+ * @service
+ * @category Science
+ */
+'use strict';
+
+// I got the list of X to support from: https://thisxdoesnotexist.com/ and a few reddit pages.
+// most are supported, but some were not applicable or inaccessible for direct download.
+
+const logger = require('../utils/logger')('this-x-does-not-exist');
+const request = require('request');
+
+const TXDNE = {};
+
+TXDNE._getX = function(rsp, url) {
+    logger.info(`requesting image from: ${url}`);
+    request.get({url, encoding: null}, (err, res, body) => {
+        rsp.set('content-type', 'image/jpeg');
+        rsp.set('content-length', body.length);
+        rsp.set('connection', 'close');
+        rsp.status(200).send(body);
+        logger.info('sent the image');
+    });
+    return null; // we're async
+};
+
+/**
+ * Gets an image of a person that does not exist
+ */
+TXDNE.getPerson = function() {
+    return TXDNE._getX(this.response, 'http://www.thispersondoesnotexist.com/image');
+};
+
+/**
+ * Gets an image of a cat that does not exist
+ */
+TXDNE.getCat = function() {
+    return TXDNE._getX(this.response, 'http://www.thiscatdoesnotexist.com');
+};
+
+/**
+ * Gets an image of a horse that does not exist
+ */
+TXDNE.getHorse = function() {
+    return TXDNE._getX(this.response, 'http://www.thishorsedoesnotexist.com');
+};
+
+/**
+ * Gets an image of an artwork that does not exist
+ */
+TXDNE.getArtwork = function() {
+    return TXDNE._getX(this.response, 'https://thisartworkdoesnotexist.com');
+};
+
+/**
+ * Gets an image of a waifu that does not exist
+ */
+TXDNE.getWaifu = function() {
+    const r = Math.floor(Math.random() * 100000);
+    return TXDNE._getX(this.response, `https://www.thiswaifudoesnotexist.net/example-${r}.jpg`);
+};
+
+/**
+ * Gets an image of a fursona that does not exist
+ */
+TXDNE.getFursona = function() {
+    const r = String(Math.floor(Math.random() * 100000)).padStart(5, '0');
+    return TXDNE._getX(this.response, `https://thisfursonadoesnotexist.com/v2/jpgs/seed${r}.jpg`);
+};
+
+/**
+ * Gets an image of a pony that does not exist
+ */
+TXDNE.getPony = function() {
+    const r = String(Math.floor(Math.random() * 100000)).padStart(5, '0');
+    return TXDNE._getX(this.response, `https://thisponydoesnotexist.net/v1/w2x-redo/jpgs/seed${r}.jpg`);
+};
+
+/**
+ * Gets an image of a home interior that does not exist
+ */
+TXDNE.getHomeInterior = function() {
+    const options = ['hero', 'img1', 'img2', 'img3', 'img4'];
+    const r = Math.floor(Math.random() * options.length);
+    return TXDNE._getX(this.response, `https://thisrentaldoesnotexist.com/img-new/${options[r]}.jpg`);
+};
+
+/**
+ * Gets an image of a congress person that does not exist
+ */
+TXDNE.getCongressPerson = function() {
+    const r = String(Math.floor(Math.random() * 651)).padStart(5, '0');
+    return TXDNE._getX(this.response, `https://vole.wtf/this-mp-does-not-exist/mp/mp${r}.jpg`);
+};
+
+module.exports = TXDNE;

--- a/src/server/services/procedures/this-x-does-not-exist/this-x-does-not-exist.js
+++ b/src/server/services/procedures/this-x-does-not-exist/this-x-does-not-exist.js
@@ -1,10 +1,13 @@
 /**
- * Provides access to images from various websites typically called this<X>doesnotexist.com.
- * These are images of X generated from random noise by (typically) a GAN.
+ * This service uses Artificial Intelligence (AI) to make random, realistic images.
+ * For a list of example websites, see https://thisxdoesnotexist.com/.
+ * These are typically made by a Generative Adversarial neural Network (GAN).
+ * Put simply, this involves two AIs: one to make images and another to guess if they're real or fake, and making them compete to mutually improve.
+ * For more information, see https://en.wikipedia.org/wiki/Generative_adversarial_network.
  * 
  * @alpha
  * @service
- * @category Science
+ * @category ArtificialIntelligence
  */
 'use strict';
 
@@ -12,20 +15,20 @@
 // most are supported, but some were not applicable or inaccessible for direct download.
 
 const logger = require('../utils/logger')('this-x-does-not-exist');
-const request = require('request');
+const axios = require('axios');
 
 const TXDNE = {};
 
-TXDNE._getX = function(rsp, url) {
+TXDNE._getX = async function(rsp, url) {
     logger.info(`requesting image from: ${url}`);
-    request.get({url, encoding: null}, (err, res, body) => {
-        rsp.set('content-type', 'image/jpeg');
-        rsp.set('content-length', body.length);
-        rsp.set('connection', 'close');
-        rsp.status(200).send(body);
-        logger.info('sent the image');
-    });
-    return null; // we're async
+    let resp = await axios({url, method: 'GET', responseType: 'arraybuffer'});
+    
+    rsp.set('content-type', 'image/jpeg');
+    rsp.set('content-length', resp.data.length);
+    rsp.set('connection', 'close');
+
+    logger.info('sent the image');
+    return rsp.status(200).send(resp.data);
 };
 
 /**

--- a/test/unit/server/services/procedures/this-x-does-not-exist.spec.js
+++ b/test/unit/server/services/procedures/this-x-does-not-exist.spec.js
@@ -1,0 +1,15 @@
+describe('this-x-does-not-exist', function() {
+    const utils = require('../../../../assets/utils');
+
+    utils.verifyRPCInterfaces('ThisXDoesNotExist', [
+        ['getPerson', []],
+        ['getCat', []],
+        ['getHorse', []],
+        ['getArtwork', []],
+        ['getWaifu', []],
+        ['getFursona', []],
+        ['getPony', []],
+        ['getHomeInterior', []],
+        ['getCongressPerson', []],
+    ]);
+});


### PR DESCRIPTION
I thought it would be neat for (esp.) games to be able to fetch random profile images, so I made an RPC for accessing images from [thispersondoesnotexist.com](thispersondoesnotexist.com). From there I found out about a bunch of other related sites, so I made RPCs for all the ones I could find. All the images sources claim to be safe (not inappropriate) and I did extensive testing on each of them (randomly) and found nothing bad. I put the service under the `Science` category for now due to being directly related to GANs.