### PR TITLE
Add exportRole to REST API. Closes #2923

### DIFF
--- a/src/server/api/core/auth.js
+++ b/src/server/api/core/auth.js
@@ -93,7 +93,8 @@ Perms.addPermissionSet('Library', {
 Perms.addPermissionSet('Project', {
     READ: function(project) {
         return requestor => assert(
-            project.Public || project.collaborators.concat(project.owner).includes(requestor),
+            project &&
+                (project.Public || project.collaborators.concat(project.owner).includes(requestor)),
             new Errors.Unauthorized(requestor, 'read project'),
         );
     }

--- a/src/server/api/core/errors.js
+++ b/src/server/api/core/errors.js
@@ -21,6 +21,14 @@ class ProjectNotFound extends RequestError {
     }
 }
 
+class ProjectRoleNotFound extends RequestError {
+    constructor(name) {
+        const msg = name ? `Could not find the given role in "${name}"` :
+            'Role not found';
+        super(msg);
+    }
+}
+
 class LibraryNotFound extends RequestError {
     constructor(owner, name) {
         const msg = `Could not find library "${name}" for "${owner}"`;
@@ -83,5 +91,6 @@ module.exports.InvalidArgument = InvalidArgument;
 module.exports.InvalidArgumentType = InvalidArgumentType;
 module.exports.GroupNotFound = GroupNotFound;
 module.exports.ProjectNotFound = ProjectNotFound;
+module.exports.ProjectRoleNotFound = ProjectRoleNotFound;
 module.exports.LibraryNotFound = LibraryNotFound;
 module.exports.RequestError = RequestError;

--- a/src/server/api/core/projects.js
+++ b/src/server/api/core/projects.js
@@ -147,7 +147,7 @@ class Projects {
     async _setProjectPublished(owner, name, isPublished=false) {
         const query = {owner, name};
         const result = await ProjectsStorage.updateCustom(query, {$set: {Public: isPublished}});
-        assert(result.matchedCount === 0, new ProjectNotFound(name));
+        assert(result.matchedCount !== 0, new ProjectNotFound(name));
     }
 
     async newProject(owner, roleName='myRole', clientId=null) {

--- a/src/server/api/core/projects.js
+++ b/src/server/api/core/projects.js
@@ -147,9 +147,7 @@ class Projects {
     async _setProjectPublished(owner, name, isPublished=false) {
         const query = {owner, name};
         const result = await ProjectsStorage.updateCustom(query, {$set: {Public: isPublished}});
-        if (result.matchedCount === 0) {
-            throw new Errors.ProjectNotFound(name);
-        }
+        assert(result.matchedCount === 0, new ProjectNotFound(name));
     }
 
     async newProject(owner, roleName='myRole', clientId=null) {
@@ -237,7 +235,7 @@ class Projects {
 
     async getProjectByName(owner, name, requestor) {
         let project = await ProjectsStorage.get(owner, name);
-        if (!project) throw new Errors.ProjectNotFound(name);
+        assert(project, new ProjectNotFound(name));
         if (requestor && requestor !== owner) {  // send a copy
             project = await project.getCopyFor(requestor);
         }
@@ -256,7 +254,7 @@ class Projects {
     async getPublicProject(owner, name) {
         await this._ensureValidUser(owner);
         const project = await this.getProjectSafe(owner, name);
-        if (!project.Public) throw new Errors.ProjectNotFound(name);
+        assert(project.Public, new ProjectNotFound(name));
         return project;
     }
 
@@ -265,7 +263,7 @@ class Projects {
             await ProjectsStorage.get(projectIdOrOwner, name) :
             await ProjectsStorage.getById(projectIdOrOwner);
 
-        if (!project) throw new Errors.ProjectNotFound(name);
+        assert(project, new ProjectNotFound(name));
         return project;
     }
 
@@ -288,7 +286,7 @@ class Projects {
 
     async _ensureValidUser(username) {
         const user = await UsersData.get(username);
-        if (!user) throw new Errors.UserNotFound(username);
+        assert(user, new UserNotFound(username));
     }
 
     _getProjectMetadata(project, origin='') {

--- a/src/server/api/core/projects.js
+++ b/src/server/api/core/projects.js
@@ -7,7 +7,8 @@ const ProjectsStorage = require('../../storage/projects');
 const UsersData = require('../../storage/users');
 const NetworkTopology = require('../../network-topology');
 const Utils = require('../../server-utils.js');
-const Errors = require('./errors');
+const {ProjectNotFound, ProjectRoleNotFound, UserNotFound} = require('./errors');
+const assert = require('assert');
 const _ = require('lodash');
 const Auth = require('./auth');
 const P = Auth.Permission;
@@ -19,40 +20,40 @@ class Projects {
 
     async exportProject(requestor, projectId) {
         const project = await ProjectsStorage.getById(projectId);
+        assert(project, new ProjectNotFound());
         await Auth.ensureAuthorized(requestor, P.Project.READ(project));
 
-        const occupantForRole = {};
-
-        // Get the first occupant for each role
-        NetworkTopology.getSocketsAtProject(projectId).reverse()
-            .forEach(socket => {
-                occupantForRole[socket.roleId] = socket;
-            });
-
-        // For each role...
-        //   - if it is occupied, request the content
-        //   - else, use the content from the database
-        const ids = await project.getRoleIds();
-        const fetchers = ids.map(id => {
-            const occupant = occupantForRole[id];
-            if (occupant) {
-                return occupant.getProjectJson()
-                    .catch(err => {
-                        this._logger.info(`Failed to retrieve project via ws. Falling back to content from database... (${err.message})`);
-                        return project.getRoleById(id);
-                    });
-            }
-            return project.getRoleById(id);
-        });
-
-        const roles = await Promise.all(fetchers);
-        const roleContents = roles.map(content =>
-            Utils.xml.format('<role name="@">', content.ProjectName)
-            + content.SourceCode + content.Media + '</role>'
+        const roleIds = await project.getRoleIds();
+        const roleContents = await Promise.all(
+            roleIds.map(roleId => this.exportRole(requestor, projectId, roleId, project))
         );
+
         const xml = Utils.xml.format('<room name="@" app="@">', project.name, Utils.APP) +
             roleContents.join('') + '</room>';
         this.logger.trace(`Exporting project ${projectId} for ${requestor}`);
+
+        return xml;
+    }
+
+    async exportRole(requestor, projectId, roleId, project=null) {
+        if (!project) {
+            project = await ProjectsStorage.getById(projectId);
+            assert(project, new ProjectNotFound());
+        }
+        await Auth.ensureAuthorized(requestor, P.Project.READ(project));
+        const isValidRoleId = project.roles[roleId];
+        assert(isValidRoleId, new ProjectRoleNotFound(project.name));
+
+        // TODO: Can I ensure that I am getting the latest?
+        const [occupant] = NetworkTopology.getSocketsAt(projectId, roleId);
+        const content = occupant ? 
+            await occupant.getProjectJson().catch(err => {
+                this._logger.info(`Failed to retrieve project via ws. Falling back to content from database... (${err.message})`);
+                return project.getRoleById(roleId);
+            }) : await project.getRoleById(roleId);
+
+        const xml = Utils.xml.format('<role name="@">', content.ProjectName)
+            + content.SourceCode + content.Media + '</role>';
 
         return xml;
     }

--- a/test/unit/server/api/core/projects.js
+++ b/test/unit/server/api/core/projects.js
@@ -20,16 +20,56 @@ describe('projects', function() {
         it('should export project', async function() {
             const xml = await ProjectsAPI.exportProject(username, project.getId());
             assert(xml.startsWith('<room'));
+            // TODO: Check all the roles
         });
 
-        it('should fetch latest role content in export', async function() {
-            // TODO
+        it('should throw unauthorized if non-existent project', async function() {
+            await utils.shouldThrow(
+                () => ProjectsAPI.exportProject(otherUser, 'IDontExist'),
+                Errors.Unauthorized
+            );
         });
 
         it('should not export other user projects', async function() {
             const privateProject = projects.find(project => !project.Public);
             await utils.shouldThrow(
                 () => ProjectsAPI.exportProject(otherUser, privateProject.getId()),
+                Errors.Unauthorized
+            );
+        });
+    });
+
+    describe.only('exportRole', function() {
+        it('should export role', async function() {
+            const [roleId] = await project.getRoleIds();
+            const xml = await ProjectsAPI.exportRole(username, project.getId(), roleId);
+            assert(xml.startsWith('<role'), `Expected role XML but found: ${xml}`);
+            assert(xml.includes('<media'), `Role XML missing <media/>: ${xml}`);
+        });
+
+        it('should fetch latest role content in export', async function() {
+            // TODO
+        });
+
+        it('should throw unauthorized if non-existent project', async function() {
+            await utils.shouldThrow(
+                () => ProjectsAPI.exportRole(otherUser, 'IDontExist', 'NotReal'),
+                Errors.ProjectNotFound
+            );
+        });
+
+        it('should throw unauthorized if non-existent role', async function() {
+            await utils.shouldThrow(
+                () => ProjectsAPI.exportRole(otherUser, project.getId(), 'NotReal'),
+                Errors.ProjectRoleNotFound
+            );
+        });
+
+        it('should not export other user projects', async function() {
+            const privateProject = projects.find(project => !project.Public);
+            const [roleId] = await privateProject.getRoleIds();
+            await utils.shouldThrow(
+                () => ProjectsAPI.exportRole(otherUser, privateProject.getId(), roleId),
                 Errors.Unauthorized
             );
         });

--- a/test/unit/server/api/core/projects.js
+++ b/test/unit/server/api/core/projects.js
@@ -39,7 +39,7 @@ describe('projects', function() {
         });
     });
 
-    describe.only('exportRole', function() {
+    describe('exportRole', function() {
         it('should export role', async function() {
             const [roleId] = await project.getRoleIds();
             const xml = await ProjectsAPI.exportRole(username, project.getId(), roleId);

--- a/test/unit/server/api/core/projects.js
+++ b/test/unit/server/api/core/projects.js
@@ -51,16 +51,16 @@ describe('projects', function() {
             // TODO
         });
 
-        it('should throw unauthorized if non-existent project', async function() {
+        it('should throw "project not found" if non-existent project', async function() {
             await utils.shouldThrow(
-                () => ProjectsAPI.exportRole(otherUser, 'IDontExist', 'NotReal'),
+                () => ProjectsAPI.exportRole(username, 'IDontExist', 'NotReal'),
                 Errors.ProjectNotFound
             );
         });
 
-        it('should throw unauthorized if non-existent role', async function() {
+        it('should throw "role not found" if non-existent role', async function() {
             await utils.shouldThrow(
-                () => ProjectsAPI.exportRole(otherUser, project.getId(), 'NotReal'),
+                () => ProjectsAPI.exportRole(username, project.getId(), 'NotReal'),
                 Errors.ProjectRoleNotFound
             );
         });

--- a/test/unit/server/api/core/projects.js
+++ b/test/unit/server/api/core/projects.js
@@ -23,10 +23,10 @@ describe('projects', function() {
             // TODO: Check all the roles
         });
 
-        it('should throw unauthorized if non-existent project', async function() {
+        it('should throw not found if non-existent project', async function() {
             await utils.shouldThrow(
                 () => ProjectsAPI.exportProject(otherUser, 'IDontExist'),
-                Errors.Unauthorized
+                Errors.ProjectNotFound
             );
         });
 


### PR DESCRIPTION
This PR adds support for fetching the latest version of a role via the REST API. Note that this includes unsaved edits as these are the key issue in #2923. That said, the remainder of the fix will be implemented on the client; this provides backend support for prompting the user to reload with the latest (even unsaved) version of the project. Essentially, this will fetch the latest version of the given role and then load it.