### PR TITLE
Minor code cleanup

### DIFF
--- a/src/server/storage/blob/blob.js
+++ b/src/server/storage/blob/blob.js
@@ -9,7 +9,6 @@
 //   - get(hash): Promise<data>
 
 const hash = require('../../../common/sha512').hex_sha512;
-const Q = require('q');
 
 // Backends
 const S3Backend = require('./s3');
@@ -33,11 +32,10 @@ class BlobStorage {
         return this.backend.get(id);
     }
 
-    store(data) {
+    async store(data) {
         const id = hash(data);
-        this.logger.trace(`Storing data for ${id}`);
-        return Q(this.backend.store(id, data))
-            .then(() => id);
+        await this.backend.store(id, data);
+        return id;
     }
 
     // List all ids (for migrations)

--- a/src/server/storage/blob/fs.js
+++ b/src/server/storage/blob/fs.js
@@ -53,8 +53,6 @@ class FSBackend {
     store(id, data) {
         const [dirname, filename] = this.getDirectoryAndFile(id);
 
-        this.logger.info(`storing data in the blob: ${id}`);
-
         // store the data and return the hash
         this._verifyExists();
         return Q.nfcall(fse.ensureDir, dirname)
@@ -62,7 +60,6 @@ class FSBackend {
                 if (!exists.sync(filename)) {
                     return Q.nfcall(fs.writeFile, filename, data);
                 } else {
-                    this.logger.trace(`data already stored. skipping write ${id}`);
                     return Q();
                 }
             })

--- a/test/unit/server/services/procedures/connectn.spec.js
+++ b/test/unit/server/services/procedures/connectn.spec.js
@@ -1,4 +1,3 @@
-/*globals describe,it,before,beforeEach,afterEach*/
 describe('ConnectN Tests', function() {
     const utils = require('../../../../assets/utils');
     var ConnectN = utils.reqSrc('services/procedures/connect-n/connect-n.js'),


### PR DESCRIPTION
This reduces the somewhat excessive logs when saving data to the blob, removes unneeded globals (for the linter), and removes Q in favor of async/await.