### PR TITLE
Implicit x-values are 1-indexed in Chart.draw. Closes #3017

### DIFF
--- a/src/server/services/procedures/chart/chart.js
+++ b/src/server/services/procedures/chart/chart.js
@@ -69,7 +69,7 @@ function calcRanges(lines, isCategorical){
     return stats;
 }
 
-function prepareData(input, options) {
+chart._prepareData = function(input, options=defaults){
     const xShouldBeNumeric = !options.isCategorical && !options.isTimeSeries;
     
     // if the input is one line convert it to appropriate format
@@ -89,7 +89,7 @@ function prepareData(input, options) {
 
         // If only one dimension is given
         if(line.every(pt => !Array.isArray(pt))){
-            line = line.map((pt,idx) => ([idx, pt]));
+            line = line.map((pt,idx) => ([idx + 1, pt]));
         }
 
         line.map(pt => {
@@ -185,7 +185,7 @@ chart._parseDrawInputs = function(lines, options){
 
     // prepare and check for errors in data
     try {
-        lines = prepareData(lines, options);
+        lines = this._prepareData(lines, options);
     } catch (e) {
         this._logger.error(e);
         this.response.status(500).send(e);

--- a/src/server/services/procedures/chart/chart.js
+++ b/src/server/services/procedures/chart/chart.js
@@ -111,7 +111,7 @@ chart._prepareData = function(input, options=defaults){
         return line;
     });
     return input;
-}
+};
 
 /**
  * Truncates a string with an elipsis if it is too long.

--- a/test/unit/server/services/procedures/chart/chart.spec.js
+++ b/test/unit/server/services/procedures/chart/chart.spec.js
@@ -38,6 +38,26 @@ describe(utils.suiteName(__filename), function() {
         assert.deepEqual(opts.map(i => i[0]), expectedOpts);
     });
 
+    describe('parseDrawInputs', function() {
+        it('should support implicit x-values', function() {
+            const inputLine = [[2, 3, 4, 5, 6]];
+            const [lineData] = Chart._prepareData(inputLine);
+            lineData.forEach(pair => {
+                const [x, y] = pair;
+                assert.equal(x + 1, y);
+            });
+        });
+
+        it('should support single line input', function() {
+            const inputLine = [2, 3, 4, 5, 6];
+            const [lineData] = Chart._prepareData(inputLine);
+            lineData.forEach(pair => {
+                const [x, y] = pair;
+                assert.equal(x + 1, y);
+            });
+        });
+    });
+
     describe('logscale', function() {
         it('should allow empty axes', function(){
             let options = Chart._parseDrawInputs([], {logscale: ''})[1];


### PR DESCRIPTION
This PR ensures that implicit x values are 1-indexed (like NetsBlox). It also includes some refactoring to ensure the changes are easily testable.
