### PR TITLE
chart 2xN transposing and error cleanup

### DIFF
--- a/src/server/services/procedures/chart/chart.js
+++ b/src/server/services/procedures/chart/chart.js
@@ -91,13 +91,6 @@ chart._prepareData = function(input, options=defaults){
             line = line.map((pt,idx) => ([idx + 1, pt]));
         }
 
-        // if we got 2xN for N >= 3, transpose it
-        if (line.length === 2 && line.every(pt => Array.isArray(pt) && pt.length >= 3) && line[0].length === line[1].length) {
-            const res = [];
-            for (let i = 0; i < line[0].length; ++i) res.push([line[0][i], line[1][i]]);
-            line = res;
-        }
-
         line.map(pt => {
             if (!Array.isArray(pt) || pt.length !== 2) {
                 chart._logger.warn('input point is not in [x,y] form', pt);


### PR DESCRIPTION
This adds a behavior to the chart line parser that allows 2xN (N >= 3) to be automatically transposed into the accepted Nx2 form (which is really just zipping). There's currently code that allows only one line to be passed, and logic to allow drawing lines with only y values. So the only issue I see so far is that passing `[x,y]` would be ambiguous between `[[x, y]]` (one transposed line) and `[[x], [y]]` (two lines with only y values).

Also I cleaned up some of the error handling code: unnecessary try-catch on internal functions, throwing strings instead of `Error`, and directly manipulating the response object to set errors.