### PR TITLE
Add port endpoints for services

### DIFF
--- a/src/server/services/procedures/iotscape/routes.js
+++ b/src/server/services/procedures/iotscape/routes.js
@@ -1,0 +1,11 @@
+const express = require('express');
+const router = express();
+
+router.get(
+    '/services/iotscape/port',
+    async (_, res) => {
+        res.status(200).send(process.env.IOTSCAPE_PORT || 'IoTScape is not enabled.');
+    }
+);
+
+module.exports = router;

--- a/src/server/services/procedures/phone-iot/routes.js
+++ b/src/server/services/procedures/phone-iot/routes.js
@@ -1,0 +1,11 @@
+const express = require('express');
+const router = express();
+
+router.get(
+    '/services/phone-iot/port',
+    async (_, res) => {
+        res.status(200).send(process.env.PHONE_IOT_PORT || 'PhoneIoT is not enabled.');
+    }
+);
+
+module.exports = router;

--- a/src/server/services/procedures/roboscape/routes.js
+++ b/src/server/services/procedures/roboscape/routes.js
@@ -6,7 +6,8 @@ const logger = require('../utils/logger')('roboscape:routes');
 const Users = require('../../../storage/users');
 const RoboscapeCol = require('./database'); // roboscape model
 
-const BASE_ENDPOINT = 'roboscape/robots';
+const BASE_ENDPOINT = 'roboscape';
+const ROBOTS_ENDPOINT = BASE_ENDPOINT + '/robots';
 
 /**
  * routes for:
@@ -156,10 +157,9 @@ const routes = [
             return setUserAccess(req.params._id, body.username, body.hasAccess);
         }
     },
-
 ]
     .map(route => { // handle the actual sending of the results
-        route.URL = BASE_ENDPOINT + route.URL;
+        route.URL = ROBOTS_ENDPOINT + route.URL;
         let handler = route.Handler;
         route.Handler = async (req, res, next) => {
 
@@ -188,5 +188,16 @@ const routes = [
         };
         return route;
     });
+
+routes.push(
+    { // Get RoboScape port
+        URL: BASE_ENDPOINT + '/port',
+        Method: 'get',
+        middleware: [],
+        Handler: async (_, res) => {
+            res.status(200).send(process.env.ROBOSCAPE_PORT || 'RoboScape is not enabled.');
+        }
+    }
+);
 
 module.exports = routes;


### PR DESCRIPTION
Closes #3022

Adds `api/services/iotscape/port`, `api/roboscape/port`, and `api/services/phone-iot/port` endpoints. They either provide the port or respond that it is not enabled (Should the endpoints return a different status code for that case?).