### PR TITLE
Add categories to RPC metadata. Closes #3033

### DIFF
--- a/src/server/services/jsdoc-extractor.js
+++ b/src/server/services/jsdoc-extractor.js
@@ -44,9 +44,12 @@ function simplify(metadata) {
     if (returns) returns = {type: new InputType(returns.type), description: returns.description};
 
     const isDeprecated = !!tags.find(tag => tag.title === 'deprecated');
+    const categories = tags.filter(tag => tag.title === 'category')
+        .map(tag => tag.description.split(';').map(c => c.trim()));
     let simplified = {
         name: fnName,
         deprecated: isDeprecated,
+        categories,
         description,
         args,
         returns

--- a/src/server/services/procedures/dev/dev.js
+++ b/src/server/services/procedures/dev/dev.js
@@ -77,6 +77,7 @@ dev.sum = function(numbers) {
 
 /**
  * Fetch debug logs for debugging remotely.
+ * @category logging
  */
 dev.getLogs = function() {
     return devLogger.read();
@@ -84,6 +85,7 @@ dev.getLogs = function() {
 
 /**
  * Fetch debug logs for debugging remotely.
+ * @category logging
  */
 dev.clearLogs = function() {
     return devLogger.clear();

--- a/test/unit/server/services/jsdoc-extractor.spec.js
+++ b/test/unit/server/services/jsdoc-extractor.spec.js
@@ -60,40 +60,27 @@ describe(utils.suiteName(__filename), function() {
         });
 
         it('should simplify the metadata', () => {
+            const arg = (name, type, description) => ({
+                name,
+                optional: false,
+                type: {
+                    name: type,
+                    params: []
+                },
+                description,
+            });
             let simpleMetadata = jp._simplify(metadata.parsed);
+
             assert.deepEqual(simpleMetadata, {
                 name: 'doStuff',
                 description: metadata.parsed.description,
                 deprecated: false,
                 args: [
-                    {
-                        name: 'address',
-                        optional: false,
-                        type: {
-                            name: 'String',
-                            params: []
-                        },
-                        description: 'target address'
-                    },
-                    {
-                        name: 'limit',
-                        optional: false,
-                        type: {
-                            name: 'Number',
-                            params: []
-                        },
-                        description: 'the results limit'
-                    },
-                    {
-                        name: 'options',
-                        optional: false,
-                        type: {
-                            name: 'Object',
-                            params: []
-                        },
-                        description: null
-                    }
+                    arg('address', 'String', 'target address'),
+                    arg('limit', 'Number', 'the results limit'),
+                    arg('options', 'Object', null),
                 ],
+                categories: [],
                 returns: {type: {name: 'String', params: []}, description: null}
             });
         });

--- a/test/unit/server/services/jsdoc-extractor.spec.js
+++ b/test/unit/server/services/jsdoc-extractor.spec.js
@@ -176,6 +176,43 @@ describe(utils.suiteName(__filename), function() {
             });
         });
 
+        describe('categories', function() {
+            it('should parse category', () => {
+                const comment = `
+                /**
+                 * this is the description
+                 * @category TestCategory
+                 * @param {Array<Array<BoundedNumber<1, 5>>>} numberLists
+                 * @name testNestedParams
+                 */
+                `;
+                const metadata = jp._simplify(jp._parseSource(comment).rpcs[0].parsed);
+                const [category] = metadata.categories;
+                assert.equal(
+                    category,
+                    'TestCategory',
+                );
+            });
+
+            it('should parse multiple categories', () => {
+                const comment = `
+                /**
+                 * this is the description
+                 * @category Category0
+                 * @category Category1;Category2;Category3
+                 * @param {Array<Array<BoundedNumber<1, 5>>>} numberLists
+                 * @name testNestedParams
+                 */
+                `;
+                const metadata = jp._simplify(jp._parseSource(comment).rpcs[0].parsed);
+                const categories = metadata.categories;
+                assert.equal(categories.length, 2);
+                assert.equal(categories[0].length, 1);
+                assert.equal(categories[1].length, 3);
+
+                categories.flat().forEach((name, i) => assert.equal(name, `Category${i}`));
+            });
+        });
     });
 
     describe('Docs', () => {


### PR DESCRIPTION
This PR adds support for specifying a set of categories for RPCs and should be useful for PhoneIoT (as well as others). Categories are optional but can be specified with:
```javascript
    /**
     * Add a custom image display to the device, which is initially empty.
     * This can be used to display an image, or to retrieve an image taken from the device's camera.
     * If an event is provided, it will be raised every time the user stores a new image in it (params: 'id').
     * Returns the id of the created control, which is used by other RPCs.
     * @category Display
     * @param {string} device name of the device (matches at the end)
     * @param {BoundedNumber<0, 100>} x X position of the top left corner of the image display (percentage).
     * @param {BoundedNumber<0, 100>} y Y position of the top left corner of the image display (percentage).
     * @param {BoundedNumber<0, 100>} width Width of the image display (percentage).
     * @param {BoundedNumber<0, 100>} height Height of the image display (percentage).
     * @param {Object=} options Additional options: id, event
     * @returns {string} id of the created button
     */
    PhoneIoT.prototype.addImageDisplay = function (device, x, y, width, height, options) {

```

@dragazo 