### PR TITLE
Add duck typing for Objects. Closes #3070

### DIFF
--- a/src/server/services/procedures/dev/dev.js
+++ b/src/server/services/procedures/dev/dev.js
@@ -76,6 +76,18 @@ dev.sum = function(numbers) {
 };
 
 /**
+ * Call an argument with a duck typed options object
+ *
+ * @param{Object} options
+ * @param{String} options.name
+ * @param{Number} options.age
+ * @param{Number=} options.height
+ */
+dev.echoOptionsExample = function(options) {
+    return options;
+};
+
+/**
  * Fetch debug logs for debugging remotely.
  * @category logging
  */

--- a/test/unit/server/services/input-types.spec.js
+++ b/test/unit/server/services/input-types.spec.js
@@ -77,7 +77,7 @@ describe(utils.suiteName(__filename), function() {
             assert.deepEqual(parsedInput.name, 'Hamid');
         });
 
-        describe.only('duck typing', function() {
+        describe('duck typing', function() {
             function param(name, type, optional=false) {
                 return {
                     name,

--- a/test/unit/server/services/input-types.spec.js
+++ b/test/unit/server/services/input-types.spec.js
@@ -77,6 +77,45 @@ describe(utils.suiteName(__filename), function() {
             assert.deepEqual(parsedInput.name, 'Hamid');
         });
 
+        describe.only('duck typing', function() {
+            function param(name, type, optional=false) {
+                return {
+                    name,
+                    optional,
+                    type: {
+                        name: type
+                    }
+                };
+            }
+
+            it('should not support additional fields', function() {
+                const input = [['name', 'Donald Duck'], ['age', 50]];
+                assert.throws(
+                    () => typesParser.Object(input, [param('name', 'String')]),
+                    /extra fields/
+                );
+            });
+
+            it('should support optional fields', function() {
+                const input = [];
+                const parsedInput = typesParser.Object(input, [param('name', 'String', true)]);
+                assert.deepEqual(parsedInput, {});
+            });
+
+            it('should parse fields', function() {
+                const input = [['age', '50']];
+                const parsedInput = typesParser.Object(input, [param('age', 'Number')]);
+                assert.deepEqual(parsedInput.age, 50);
+            });
+
+            it('should support required fields', function() {
+                const input = [['name', 'Donald Duck']];
+                assert.throws(
+                    () => typesParser.Object(input, [param('name', 'String'), param('age', 'Number')]),
+                    /Must contain/
+                );
+            });
+        });
     });
 
     describe('Latitude', function() {

--- a/test/unit/server/services/input-types.spec.js
+++ b/test/unit/server/services/input-types.spec.js
@@ -112,7 +112,7 @@ describe(utils.suiteName(__filename), function() {
                 const input = [['name', 'Donald Duck']];
                 assert.throws(
                     () => typesParser.Object(input, [param('name', 'String'), param('age', 'Number')]),
-                    /Must contain/
+                    /must contain/
                 );
             });
         });

--- a/test/unit/server/services/jsdoc-extractor.spec.js
+++ b/test/unit/server/services/jsdoc-extractor.spec.js
@@ -163,6 +163,36 @@ describe(utils.suiteName(__filename), function() {
             });
         });
 
+        describe('duck typing', function() {
+            let parsed;
+            before(() => {
+                const duckTypes = `
+                /**
+                 * this is the description
+                 * @param {Object} duck some duck-typed object (aka anonymous struct)
+                 * @param {String} duck.name name of the given duck
+                 * @param {Number} duck.age age of the given duck
+                 * @name doSomething
+                 */
+                `;
+                const metadata = jp._parseSource(duckTypes).rpcs[0];
+                parsed = jp._simplify(metadata.parsed);
+                console.log(parsed.args);
+            });
+
+            it('should parse field names', () => {
+                const [duckArg] = parsed.args;
+                const fieldNames = duckArg.type.params.map(field => field.name);
+                assert.deepEqual(fieldNames, ['name', 'age']);
+            });
+
+            it('should parse field types', () => {
+                const [duckArg] = parsed.args;
+                const fieldTypes = duckArg.type.params.map(field => field.type.name);
+                assert.deepEqual(fieldTypes, ['String', 'Number']);
+            });
+        });
+
         describe('categories', function() {
             it('should parse category', () => {
                 const comment = `


### PR DESCRIPTION
This adds support for duck typing objects passed as arguments to RPCs. As an example:
```javascript
/**
 * Call an argument with a duck typed options object
 *
 * @param{Object} options
 * @param{String} options.name
 * @param{Number} options.age
 * @param{Number=} options.height
 */
```