### PR TITLE
added Array type bounds and complex inner types

### DIFF
--- a/src/server/services/input-types.js
+++ b/src/server/services/input-types.js
@@ -128,7 +128,7 @@ types.Array = (input, params=[]) => {
     const [typeParam, min=0, max=Infinity] = params;
     const innerType = getTypeParser(typeParam);
 
-    if (!Array.isArray(input)) throw new InputTypeError('Not a list');
+    if (!Array.isArray(input)) throw new InputTypeError();
     if (innerType) {
         let i = 0;
         try {

--- a/src/server/services/input-types.js
+++ b/src/server/services/input-types.js
@@ -40,7 +40,7 @@ function getNBType(jsType) {
 
 const types = {};
 
-function grabType(type) {
+function getTypeParser(type) {
     if (!type) return undefined;
 
     const t = types[type];
@@ -124,13 +124,13 @@ types.Date = input => {
     return input;
 };
 
-types.Array = (input, params) => {
-    const [_innerType, min, max] = params;
-    const innerType = grabType(_innerType);
+types.Array = (input, params=[]) => {
+    const [typeParam, min=0, max=Infinity] = params;
+    const innerType = getTypeParser(typeParam);
 
     if (!Array.isArray(input)) throw new InputTypeError('Not a list');
     if (innerType) {
-        let i = 0
+        let i = 0;
         try {
             for (; i < input.length; ++i) input[i] = innerType(input[i]);
         }
@@ -138,8 +138,9 @@ types.Array = (input, params) => {
             throw new ParameterError(`Item ${i+1} ${e}`);
         }
     }
-    if (min && input.length < min) throw new ParameterError(`Length must be at least ${min}`);
-    if (max && input.length > max) throw new ParameterError(`Length must be at most ${max}`);
+    if (min && min === max && input.length !== min) throw new ParameterError(`List must contain ${min} items`);
+    if (min && input.length < min) throw new ParameterError(`List must contain at least ${min} items`);
+    if (max && input.length > max) throw new ParameterError(`List must contain at most ${max} items`);
     return input;
 };
 

--- a/src/server/services/input-types.js
+++ b/src/server/services/input-types.js
@@ -138,9 +138,9 @@ types.Array = (input, params=[]) => {
             throw new ParameterError(`Item ${i+1} ${e}`);
         }
     }
-    if (min && min === max && input.length !== min) throw new ParameterError(`List must contain ${min} items`);
-    if (min && input.length < min) throw new ParameterError(`List must contain at least ${min} items`);
-    if (max && input.length > max) throw new ParameterError(`List must contain at most ${max} items`);
+    if (min === max && input.length !== min) throw new ParameterError(`List must contain ${min} items`);
+    if (input.length < min) throw new ParameterError(`List must contain at least ${min} items`);
+    if (input.length > max) throw new ParameterError(`List must contain at most ${max} items`);
     return input;
 };
 

--- a/test/unit/server/services/input-types.spec.js
+++ b/test/unit/server/services/input-types.spec.js
@@ -51,6 +51,28 @@ describe(utils.suiteName(__filename), function() {
         it('should support nested types', () => {
             typesParser.Array([1, 2], ['Number']);
         });
+        it('should support complex nested types', () => {
+            typesParser.Array([1, 2], [{ name: 'BoundedNumber', params: [1, 2] }]);
+        });
+
+        it('should enforce bounded lengths', () => {
+            assert.throws(() => typesParser.Array([], [undefined, 2]));
+            assert.throws(() => typesParser.Array([1], [undefined, 2]));
+            typesParser.Array([1, 2], [undefined, 2]);
+            typesParser.Array([1, 2, 3], [undefined, 2]);
+
+            assert.throws(() => typesParser.Array([1, 2, 3, 4, 5, 6], [undefined, undefined, 4]));
+            assert.throws(() => typesParser.Array([1, 2, 3, 4, 5], [undefined, undefined, 4]));
+            typesParser.Array([1, 2, 3, 4], [undefined, undefined, 4]);
+            typesParser.Array([1, 2, 3], [undefined, undefined, 4]);
+
+            assert.throws(() => typesParser.Array([], [undefined, 3, 4]));
+            assert.throws(() => typesParser.Array([1], [undefined, 3, 4]));
+            assert.throws(() => typesParser.Array([1, 2], [undefined, 3, 4]));
+            assert.throws(() => typesParser.Array([1, 2, 3, 4, 5], [undefined, 3, 4]));
+            typesParser.Array([1, 2, 3, 4], [undefined, 3, 4]);
+            typesParser.Array([1, 2, 3], [undefined, 3, 4]);
+        });
     });
 
     describe('Object', function() {


### PR DESCRIPTION
This PR adds two features to the `Array` input type. First, it adds upper and lower bounds for length, like `BoundedString` does. This can be specified like `@param {Array<Any, 2, 5>}`. Second, it adds support for complex inner types. It looks like the parser for inner types always yields an object of form `{ name: String, params: Any[] }` for inner types having angled brackets, so I added a wrapper for working with those. So now you can do complex types like a list of 0/1 as `@param {Array<Enum<0,1>>}`. Or perhaps more useful, `@param {Array<BoundedNumber<0>>}` for a list of non-negative numbers.