### PR TITLE
Serve readthedocs

### DIFF
--- a/src/server/services/input-types.js
+++ b/src/server/services/input-types.js
@@ -128,7 +128,7 @@ types.Array = (input, params=[]) => {
     const [typeParam, min=0, max=Infinity] = params;
     const innerType = getTypeParser(typeParam);
 
-    if (!Array.isArray(input)) throw new InputTypeError('Not a list');
+    if (!Array.isArray(input)) throw new InputTypeError();
     if (innerType) {
         let i = 0;
         try {

--- a/src/server/services/input-types.js
+++ b/src/server/services/input-types.js
@@ -40,7 +40,7 @@ function getNBType(jsType) {
 
 const types = {};
 
-function grabType(type) {
+function getTypeParser(type) {
     if (!type) return undefined;
 
     const t = types[type];
@@ -124,13 +124,13 @@ types.Date = input => {
     return input;
 };
 
-types.Array = (input, params) => {
-    const [_innerType, min, max] = params;
-    const innerType = grabType(_innerType);
+types.Array = (input, params=[]) => {
+    const [typeParam, min=0, max=Infinity] = params;
+    const innerType = getTypeParser(typeParam);
 
     if (!Array.isArray(input)) throw new InputTypeError('Not a list');
     if (innerType) {
-        let i = 0
+        let i = 0;
         try {
             for (; i < input.length; ++i) input[i] = innerType(input[i]);
         }
@@ -138,8 +138,9 @@ types.Array = (input, params) => {
             throw new ParameterError(`Item ${i+1} ${e}`);
         }
     }
-    if (min && input.length < min) throw new ParameterError(`Length must be at least ${min}`);
-    if (max && input.length > max) throw new ParameterError(`Length must be at most ${max}`);
+    if (min && min === max && input.length !== min) throw new ParameterError(`List must contain ${min} items`);
+    if (min && input.length < min) throw new ParameterError(`List must contain at least ${min} items`);
+    if (max && input.length > max) throw new ParameterError(`List must contain at most ${max} items`);
     return input;
 };
 

--- a/src/server/services/input-types.js
+++ b/src/server/services/input-types.js
@@ -138,9 +138,9 @@ types.Array = (input, params=[]) => {
             throw new ParameterError(`Item ${i+1} ${e}`);
         }
     }
-    if (min && min === max && input.length !== min) throw new ParameterError(`List must contain ${min} items`);
-    if (min && input.length < min) throw new ParameterError(`List must contain at least ${min} items`);
-    if (max && input.length > max) throw new ParameterError(`List must contain at most ${max} items`);
+    if (min === max && input.length !== min) throw new ParameterError(`List must contain ${min} items`);
+    if (input.length < min) throw new ParameterError(`List must contain at least ${min} items`);
+    if (input.length > max) throw new ParameterError(`List must contain at most ${max} items`);
     return input;
 };
 

--- a/test/unit/server/services/input-types.spec.js
+++ b/test/unit/server/services/input-types.spec.js
@@ -51,6 +51,28 @@ describe(utils.suiteName(__filename), function() {
         it('should support nested types', () => {
             typesParser.Array([1, 2], ['Number']);
         });
+        it('should support complex nested types', () => {
+            typesParser.Array([1, 2], [{ name: 'BoundedNumber', params: [1, 2] }]);
+        });
+
+        it('should enforce bounded lengths', () => {
+            assert.throws(() => typesParser.Array([], [undefined, 2]));
+            assert.throws(() => typesParser.Array([1], [undefined, 2]));
+            typesParser.Array([1, 2], [undefined, 2]);
+            typesParser.Array([1, 2, 3], [undefined, 2]);
+
+            assert.throws(() => typesParser.Array([1, 2, 3, 4, 5, 6], [undefined, undefined, 4]));
+            assert.throws(() => typesParser.Array([1, 2, 3, 4, 5], [undefined, undefined, 4]));
+            typesParser.Array([1, 2, 3, 4], [undefined, undefined, 4]);
+            typesParser.Array([1, 2, 3], [undefined, undefined, 4]);
+
+            assert.throws(() => typesParser.Array([], [undefined, 3, 4]));
+            assert.throws(() => typesParser.Array([1], [undefined, 3, 4]));
+            assert.throws(() => typesParser.Array([1, 2], [undefined, 3, 4]));
+            assert.throws(() => typesParser.Array([1, 2, 3, 4, 5], [undefined, 3, 4]));
+            typesParser.Array([1, 2, 3, 4], [undefined, 3, 4]);
+            typesParser.Array([1, 2, 3], [undefined, 3, 4]);
+        });
     });
 
     describe('Object', function() {


### PR DESCRIPTION
I don't know if this is the direction you wanted to go with hosting service documentation, but I took a swing at it. Related to #3059.

This PR currently just looks through each service on startup and checks if it has a `docs/` directory. If so, it goes into the directory and runs the shell command `make html`. The motivation for this being that this is the default scheme for readthedocs, and even if you use another tool you just need to add a makefile that invokes whatever you used. It does this asynchronously, and on success binds it to `/docs/services/<service-name>`. I tested it with PhoneIoT (`/docs/services/phone-iot`), which is currently the only service with this doc setup.

Note that if this is used, the server would have to have the readthedocs comile chain installed (not too large I don't think). Also, we should pick a consistent style. For PhoneIoT I used `sphinx_rtd_theme` because it's made by the main team and it looks very modern.