### PR TITLE
changed duck typing to ignore undefined/null

### DIFF
--- a/src/server/services/input-types.js
+++ b/src/server/services/input-types.js
@@ -176,14 +176,13 @@ types.Object = (input, params=[], ctx) => {
 
     const res = {};
     for (const param of params) {
-        if (!input.hasOwnProperty(param.name)) {
-            if (param.optional) continue;
-            else throw new ParameterError(`It must contain a(n) ${param.name} field`);
-        }
-
         const value = input[param.name];
         delete input[param.name];
-        if (value === undefined || value === null) continue; // don't forward empty values, cause they'll fail to parse
+
+        if (value === undefined || value === null) { // don't forward null values, cause they'll fail to parse
+            if (param.optional) continue;
+            throw new ParameterError(`It must contain a(n) ${param.name} field`);
+        }
 
         try {
             res[param.name] = types[param.type.name](value, param.type.params, ctx);

--- a/src/server/services/input-types.js
+++ b/src/server/services/input-types.js
@@ -178,8 +178,9 @@ types.Object = (input, params=[], ctx) => {
     for (const param of params) {
         const value = input[param.name];
         delete input[param.name];
+        const isMissingField = value === undefined || value === null;
 
-        if (value === undefined || value === null) { // don't forward null values, cause they'll fail to parse
+        if (isMissingField) {
             if (param.optional) continue;
             throw new ParameterError(`It must contain a(n) ${param.name} field`);
         }

--- a/src/server/services/input-types.js
+++ b/src/server/services/input-types.js
@@ -172,37 +172,31 @@ types.Object = (input, params=[], ctx) => {
         throw new InputTypeError('It should be a list of (key, value) pairs.');
     }
     input = _.fromPairs(input);
-    if (params.length) {
-        const pairs = params
-            .map(param => {
-                const hasField = input.hasOwnProperty(param.name);
-                if (hasField) {
-                    const value = input[param.name];
-                    delete input[param.name];
-                    try {
-                        const parsedValue = types[param.type.name](value, param.type.params, ctx);
-                        return [
-                            param.name,
-                            parsedValue
-                        ];
-                    } catch(err) {
-                        const message = `Field ${getErrorMessage(param, err)}`;
-                        throw new ParameterError(message);
-                    }
-                } else if (!param.optional) {
-                    throw new ParameterError(`It must contain a(n) ${param.name} field`);
-                }
-            })
-            .filter(pair => pair);
+    if (!params.length) return input; // no params means we accept anything, so return raw input as obj
 
-        const extraFields = Object.keys(input);
-        if (extraFields.length) {
-            throw new ParameterError(`It contains extra fields: ${extraFields.join(', ')}`);
+    const res = {};
+    for (const param of params) {
+        if (!input.hasOwnProperty(param.name)) {
+            if (param.optional) continue;
+            else throw new ParameterError(`It must contain a(n) ${param.name} field`);
         }
-        return _.fromPairs(pairs);
-    } else {
-        return input;
+
+        const value = input[param.name];
+        delete input[param.name];
+        if (value === undefined || value === null) continue; // don't forward empty values, cause they'll fail to parse
+
+        try {
+            res[param.name] = types[param.type.name](value, param.type.params, ctx);
+        } catch(err) {
+            throw new ParameterError(`Field ${getErrorMessage(param, err)}`);
+        }
     }
+
+    const extraFields = Object.keys(input);
+    if (extraFields.length) {
+        throw new ParameterError(`It contains extra fields: ${extraFields.join(', ')}`);
+    }
+    return res;
 };
 
 types.Function = async (blockXml, _params, ctx) => {

--- a/test/unit/server/services/input-types.spec.js
+++ b/test/unit/server/services/input-types.spec.js
@@ -125,6 +125,18 @@ describe(utils.suiteName(__filename), function() {
                 assert.deepEqual(parsedInput, {});
             });
 
+            it('should treat null values as unset', function() {
+                const input = [['name', null]];
+                const parsedInput = typesParser.Object(input, [param('name', 'String', true)]);
+                assert.deepEqual(parsedInput, {});
+            });
+
+            it('should treat undefined values as unset', function() {
+                const input = [['name', undefined]];
+                const parsedInput = typesParser.Object(input, [param('name', 'String', true)]);
+                assert.deepEqual(parsedInput, {});
+            });
+
             it('should parse fields', function() {
                 const input = [['age', '50']];
                 const parsedInput = typesParser.Object(input, [param('age', 'Number')]);


### PR DESCRIPTION
Closes #3098. The duck typing I added to the chart service a few days ago had an unforeseen issue: the `defaultOptions` RPC is returning undefined values (which at some point are converted to null) for some fields that default to not being set, a reasonable use case. The issue is that these values fail to parse.

This PR attempts to fix the general problem by disregarding input values that are undefined/null. I also tried to clean up the parsing code a bit.