### PR TITLE
Doc Updates

### DIFF
--- a/src/server/docs/dev/services-overview.rst
+++ b/src/server/docs/dev/services-overview.rst
@@ -18,7 +18,7 @@ At the time of this writing, there are three different types of services in Nets
 
 - Native NetsBlox Services. These services are defined in JavaScript in NetsBlox itself. Most of the documentation describes the creation of this type of service.
 - User-Defined Services. These services are created using the :doc:`/services/ServiceCreation/index` service from within NetsBlox.
-- Auxiliary (Private) Services. These services are hosted by other servers and enable users or classes to have their own private services. An example can be found `here <https://github.com/NetsBlox/Custom-Python-Services>`_.
+- Auxiliary (Private) Services. These services are hosted by other servers and enable users or classes to have their own private services. An example can be found `here <https://github.com/NetsBlox/Custom-Python-Services>`__.
 
 A comparison of the different types of services is given below:
 
@@ -27,7 +27,7 @@ A comparison of the different types of services is given below:
 How can I contribute a native service?
 --------------------------------------
 
-If you are interested in contributing a (native) custom service back to NetsBlox (or in your own fork), I would recommend starting with the `simple example <https://raw.githubusercontent.com/wiki/NetsBlox/NetsBlox/Hello-Custom-Services.md>`_ and then checking out the :doc:`best-practices`.
+If you are interested in contributing a (native) custom service back to NetsBlox (or in your own fork), I would recommend starting with the `simple example <https://raw.githubusercontent.com/wiki/NetsBlox/NetsBlox/Hello-Custom-Services.md>`__ and then checking out the :doc:`best-practices`.
 
 For examples of existing services, check out the featured projects on https://netsblox.org or the `source code <https://github.com/NetsBlox/NetsBlox/tree/master/src/server/services/procedures>`__.
 Examples include:

--- a/src/server/docs/fundamentals/handling-errors.rst
+++ b/src/server/docs/fundamentals/handling-errors.rst
@@ -13,7 +13,7 @@ These types of errors can be fixed by making sure the input is valid before usin
 Other, more difficult errors can happen during networking.
 For instance, a data packet might get lost on its way through the internet.
 If this happens, your computer will wait a few seconds and eventually give up, returning an error message.
-This is called a `dropped packet`.
+This is called a *dropped packet*.
 An easy way to fix a dropped packet error is to simply repeat the operation over and over until success.
 
 Errors in NetsBlox

--- a/src/server/docs/fundamentals/howto.rst
+++ b/src/server/docs/fundamentals/howto.rst
@@ -6,7 +6,7 @@ Signing up/in
 
 In order to save your projects to the cloud or play multiplayer games, you need to have a NetsBlox account.
 
-Open the `editor <https://editor.netsblox.org>`_ and click on the cloud icon, there you will find the signup button.
+Open the `editor <https://editor.netsblox.org>`__ and click on the cloud icon, there you will find the signup button.
 When you are filling the form make sure to use an up to date and working email address.
 After you sign up a password will be emailed to you.
 Go to your email copy the password and come back to the editor.
@@ -176,11 +176,11 @@ Playing multiplayer games
 -------------------------
 
 #. Sign in: First things first, for multiplayer games to work all the players need to be signed up and logged in. `Signing up/in`_.
-#. Find & open a game you like: you can go through the list of our examples and user created apps on `NetsBlox front page <https://netsblox.org/>`_, or have a friend share his own creation with you.
+#. Find & open a game you like: you can go through the list of our examples and user created apps on `NetsBlox front page <https://netsblox.org/>`__, or have a friend share his own creation with you.
 #. Get the participants in the game/room: 
 
     - If you are the first one opening the game (owner), to invite your opponents/teammates, go to the room tab you will see a circular view of the room and available roles. Each player occupies one role. To invite players click on a role choose invite users and search for your friend's username and hit ok to ask them to join your game.
-    - If you are being invited to a game, make sure you have the `editor <https://editor.netsblox.org>`_ open in your browser and that you are signed in. After you are invited, you will get a dialog asking you if you want to join the game.
+    - If you are being invited to a game, make sure you have the `editor <https://editor.netsblox.org>`__ open in your browser and that you are signed in. After you are invited, you will get a dialog asking you if you want to join the game.
 
 #. Start the game: make sure all the players are in by looking at the room view, if there is someone missing go back to third step. Now that you are all set, the main role can start the game by clicking on the green flag at the top right corner. You can maximize the stage (playground) by clicking on the icon.
 

--- a/src/server/services/jsdoc-extractor.js
+++ b/src/server/services/jsdoc-extractor.js
@@ -194,8 +194,8 @@ function findFn(line){
     // regexlist to find the fn name in format of [regex string, matchgroup]
     const regexList = [
         [/function (\w+)\(/, 1],
-        [/\w+\.(\w+)[\w\s]*=.*(function|=>)/, 1],
-        [/\w+\[['"`]([^'"`]+)['"`]\] *=.*(function|=>)/, 1],
+        [/\w+\.(\w+)[\w\s]*= *(.*function|.*=>|\w+(\.\w+)?;)/, 1],
+        [/\w+\[['"`]([^'"`]+)['"`]\] *= *(.*function|.*=>|\w+(\.\w+)?;)/, 1],
         [/(let|var|const) (\w+) *= *(\w|\().*=>/, 2],
         [/ *(\w+) *: *(async)? +function *\(.*\)/, 1],
     ];

--- a/src/server/services/jsdoc-extractor.js
+++ b/src/server/services/jsdoc-extractor.js
@@ -15,13 +15,17 @@ let parseSync = (filePath, searchScope = 5) => {
 };
 
 const RTD_ROLE_REGEX = /:(\w+:)?\w+:`([^`]+)`/g;
+const RTD_BOLD_REGEX = /\*\*([^*]+)\*\*/g;
 const RTD_CODE_REGEX = /``([^`]+)``/g;
 const RTD_LINK_REGEX = /`([^`]+)`_/g;
+const RTD_EMPH_REGEX = /`([^`]+)`/g;
 function cleanMarkup(str) {
     if (!str) return str;
     str = str.replace(RTD_ROLE_REGEX, '$2');
+    str = str.replace(RTD_BOLD_REGEX, '$1');
     str = str.replace(RTD_CODE_REGEX, '$1');
     str = str.replace(RTD_LINK_REGEX, '$1');
+    str = str.replace(RTD_EMPH_REGEX, '$1');
     return str;
 }
 
@@ -191,6 +195,7 @@ function findFn(line){
     const regexList = [
         [/function (\w+)\(/, 1],
         [/\w+\.(\w+)[\w\s]*=.*(function|=>)/, 1],
+        [/\w+\[['"`]([^'"`]+)['"`]\] *=.*(function|=>)/, 1],
         [/(let|var|const) (\w+) *= *(\w|\().*=>/, 2],
         [/ *(\w+) *: *(async)? +function *\(.*\)/, 1],
     ];

--- a/src/server/services/procedures/battleship/battleship.js
+++ b/src/server/services/procedures/battleship/battleship.js
@@ -245,7 +245,7 @@ Battleship.prototype.remainingShips = function(roleId) {
 
 /**
  * Get list of ship types
- * @returns {Array} Types of ships
+ * @returns {Array<String>} Types of ships
  */
 Battleship.prototype.allShips = function() {
     return Object.keys(SHIPS);

--- a/src/server/services/procedures/chart/chart.js
+++ b/src/server/services/procedures/chart/chart.js
@@ -1,5 +1,5 @@
 /**
- * Charting service powered by gnuplot
+ * A charting service powered by gnuplot.
  *
  * @service
  */
@@ -232,9 +232,9 @@ chart._parseDrawInputs = function(lines, options){
 };
 
 /**
- * Create charts and histograms from data
+ * Create charts and histograms from data.
  *
- * @param {Array} lines a single line or list of lines. Each line should be in form of [[x1,y1], [x2,y2]]
+ * @param {Array} lines a single line or list of lines. Each line should be ``[[x1,y1], [x2,y2], ...]``.
  * @param {Object=} options Configuration for graph title, axes, and more
  * @param {String=} options.title title to show on the graph
  * @param {Number=} options.width width of the returned image
@@ -253,6 +253,8 @@ chart._parseDrawInputs = function(lines, options){
  * @param {String=} options.timeInputFormat input time format for time series data
  * @param {String=} options.timeDisplayFormat output time format for time series data
  * @param {Array=} options.logscale logscale settings to use
+ * 
+ * @returns {Image} the generated chart
  */
 chart.draw = function(lines, options={}){
     const [data, parsedOptions] = this._parseDrawInputs(lines, options);
@@ -267,7 +269,9 @@ chart.draw = function(lines, options={}){
 };
 
 /**
- * Get the default options for the "draw" RPC.
+ * Get the default options for the :func:`Chart.draw` RPC.
+ * 
+ * @returns {Object} the default draw options
  */
 chart.defaultOptions = function(){
     return rpcUtils.jsonToSnapList(defaults);

--- a/src/server/services/procedures/cloud-variables/cloud-variables.js
+++ b/src/server/services/procedures/cloud-variables/cloud-variables.js
@@ -95,6 +95,7 @@ CloudVariables._setMaxLockAge = function(age) {  // for testing
  * Get the value of a cloud variable
  * @param {String} name Variable name
  * @param {String=} password Password (if password-protected)
+ * @returns {Any} the stored value
  */
 CloudVariables.getVariable = function(name, password) {
     const {sharedVars} = getCollections();
@@ -354,6 +355,7 @@ CloudVariables._onUnlockVariable = function(id) {
 /**
  * Get the value of a variable for the current user.
  * @param {String} name Variable name
+ * @returns {Any} the stored value
  */
 CloudVariables.getUserVariable = function(name) {
     const {userVars} = getCollections();
@@ -379,7 +381,7 @@ CloudVariables.getUserVariable = function(name) {
 /**
  * Set the value of the user cloud variable for the current user.
  * @param {String} name Variable name
- * @param {Any} value
+ * @param {Any} value Value to store in variable
  */
 CloudVariables.setUserVariable = function(name, value) {
     ensureLoggedIn(this.caller);

--- a/src/server/services/procedures/connect-n/connect-n.js
+++ b/src/server/services/procedures/connect-n/connect-n.js
@@ -112,6 +112,7 @@ ConnectN.prototype.play = async function(row, column) {
 
 /**
  * Check if the current game is over.
+ * @returns {Boolean} ``true`` if game over, otherwise ``false``
  */
 ConnectN.prototype.isGameOver = function() {
     var isOver = false;
@@ -130,6 +131,7 @@ ConnectN.prototype.isGameOver = function() {
 
 /**
  * Check if every position on the current board is occupied.
+ * @returns {Boolean}``true`` if the board is full, otherwise ``false``
  */
 ConnectN.prototype.isFullBoard = function() {
     for (var i = this._state.board.length; i--;) {

--- a/src/server/services/procedures/core-nlp/core-nlp.js
+++ b/src/server/services/procedures/core-nlp/core-nlp.js
@@ -1,7 +1,6 @@
 /**
  * Use CoreNLP to annotate text.
- *
- * For more information, check out https://stanfordnlp.github.io/CoreNLP/
+ * For more information, check out https://stanfordnlp.github.io/CoreNLP/.
  *
  * @service
  * @category Language
@@ -12,10 +11,11 @@ const axios = require('axios');
 const CoreNLP = {};
 const {CORE_NLP_HOST='https://corenlp.run'} = process.env;
 
-/*
- * Get a list of all supported annotators.
- *
- * Complete list available at https://stanfordnlp.github.io/CoreNLP/annotators.html
+/**
+ * Get a list of all the supported annotators.
+ * The complete list is available at https://stanfordnlp.github.io/CoreNLP/annotators.html.
+ * 
+ * @returns {Array<String>} list of supported annotators
  */
 CoreNLP.getAnnotators = function() {
     return [
@@ -49,8 +49,8 @@ CoreNLP.getAnnotators = function() {
 /**
  * Annotate text using the provided annotators.
  *
- * @param{String} text
- * @param{Array<String>=} annotators
+ * @param {String} text the text to annotate
+ * @param {Array<String>=} annotators a list of the annotators to use
  */
 CoreNLP.annotate = async function(text, annotators=['tokenize', 'ssplit', 'pos']) {
     const qsData = JSON.stringify({

--- a/src/server/services/procedures/core-nlp/core-nlp.js
+++ b/src/server/services/procedures/core-nlp/core-nlp.js
@@ -51,6 +51,7 @@ CoreNLP.getAnnotators = function() {
  *
  * @param {String} text the text to annotate
  * @param {Array<String>=} annotators a list of the annotators to use
+ * @returns {Object} structured data containing the annotation results
  */
 CoreNLP.annotate = async function(text, annotators=['tokenize', 'ssplit', 'pos']) {
     const qsData = JSON.stringify({

--- a/src/server/services/procedures/corgis/corgis.js
+++ b/src/server/services/procedures/corgis/corgis.js
@@ -35,7 +35,7 @@ const datasetsMetadata = corgiDatasets.parseDatasetsInfo();
 
 
 /**
- * Search CORGIS' datasets as provided by https://think.cs.vt.edu/corgis/
+ * Search CORGIS' datasets as provided by https://think.cs.vt.edu/corgis/.
  * Example queries:
  * cancer dataset: ``[*Year<2000 && Area=Arizona]``
  * @param {String} name dataset name

--- a/src/server/services/procedures/covid-19/covid-19.js
+++ b/src/server/services/procedures/covid-19/covid-19.js
@@ -35,9 +35,9 @@ COVID19._data.importMissingData();
  *
  * Date is in month/day/year format.
  *
- * @param{String} country Country or region
- * @param{String=} state State or province
- * @param{String=} city City
+ * @param {String} country Country or region
+ * @param {String=} state State or province
+ * @param {String=} city City
  */
 COVID19.getConfirmedCounts = async function(country, state='', city='') {
     return await this._data.getData(CONFIRMED, country, state, city);
@@ -48,9 +48,9 @@ COVID19.getConfirmedCounts = async function(country, state='', city='') {
  *
  * Date is in month/day/year format.
  *
- * @param{String} country Country or region
- * @param{String=} state State or province
- * @param{String=} city City
+ * @param {String} country Country or region
+ * @param {String=} state State or province
+ * @param {String=} city City
  */
 COVID19.getDeathCounts = async function(country, state='', city='') {
     return await this._data.getData(DEATH, country, state, city);
@@ -61,9 +61,9 @@ COVID19.getDeathCounts = async function(country, state='', city='') {
  *
  * Date is in month/day/year format.
  *
- * @param{String} country Country or region
- * @param{String=} state State or province
- * @param{String=} city City
+ * @param {String} country Country or region
+ * @param {String=} state State or province
+ * @param {String=} city City
  */
 COVID19.getRecoveredCounts = async function(country, state='', city='') {
     return await this._data.getData(RECOVERED, country, state, city);
@@ -71,6 +71,7 @@ COVID19.getRecoveredCounts = async function(country, state='', city='') {
 
 /**
  * Get a list of all countries (and states, cities) with data available.
+ * @returns {Array<Array<String>>} an array of ``[country, state, city]`` for each location with data available
  */
 COVID19.getLocationsWithData = async function() {
     const locations = await this._data.getAllLocations();
@@ -83,9 +84,9 @@ COVID19.getLocationsWithData = async function() {
 /**
  * Get the latitude and longitude for a location with data available.
  *
- * @param{String} country
- * @param{String=} state
- * @param{String=} city City
+ * @param {String} country
+ * @param {String=} state
+ * @param {String=} city City
  */
 COVID19.getLocationCoordinates = async function(country, state='', city='') {
     const data = await this._data.getLocation(country, state, city);

--- a/src/server/services/procedures/earth-orbit/earth-orbit.js
+++ b/src/server/services/procedures/earth-orbit/earth-orbit.js
@@ -3,19 +3,22 @@
  * earth orbital parameters' data. This service only uses the 2004 data. 
  *
  * For more information, check out
- * http://vo.imcce.fr/insola/earth/online/earth/earth.html
+ * http://vo.imcce.fr/insola/earth/online/earth/earth.html.
  *
- * Original datasets are available at
- * http://vo.imcce.fr/insola/earth/online/earth/La2004/INSOLN.LA2004.BTL.100.ASC
- * http://vo.imcce.fr/insola/earth/online/earth/La2004/INSOLN.LA2004.BTL.250.ASC
- * http://vo.imcce.fr/insola/earth/online/earth/La2004/INSOLN.LA2004.BTL.ASC
- * http://vo.imcce.fr/insola/earth/online/earth/La2004/INSOLP.LA2004.BTL.ASC
- * http://vo.imcce.fr/webservices/miriade/proxy.php?file=http://145.238.217.35//tmp/insola/insolaouto7Yk3u&format=text
- * http://vo.imcce.fr/webservices/miriade/proxy.php?file=http://145.238.217.38//tmp/insola/insolaouteXT96X&format=text
+ * Original datasets are available at:
+ * 
+ * - http://vo.imcce.fr/insola/earth/online/earth/La2004/INSOLN.LA2004.BTL.100.ASC
+ * - http://vo.imcce.fr/insola/earth/online/earth/La2004/INSOLN.LA2004.BTL.250.ASC
+ * - http://vo.imcce.fr/insola/earth/online/earth/La2004/INSOLN.LA2004.BTL.ASC
+ * - http://vo.imcce.fr/insola/earth/online/earth/La2004/INSOLP.LA2004.BTL.ASC
+ * - http://vo.imcce.fr/webservices/miriade/proxy.php?file=http://145.238.217.35//tmp/insola/insolaouto7Yk3u&format=text
+ * - http://vo.imcce.fr/webservices/miriade/proxy.php?file=http://145.238.217.38//tmp/insola/insolaouteXT96X&format=text
+ * 
  * @service
  * @category Science
  * @category Climate
  */
+
 const fs = require('fs');
 const path = require('path');
 const assert = require('assert');
@@ -94,11 +97,10 @@ EarthOrbit._dataPrecession = fs.readFileSync(path.join(__dirname, 'precession.tx
  * Get longitude of perihelion from moving equinox by year. For more information about this, please visit:
  * https://www.physics.ncsu.edu/classes/astron/orbits.html
  *
- * If a start and end year is provided, only measurements within the given range will be
- * returned.
+ * If ``startyear`` or ``endyear`` is provided, only measurements within the given range will be returned.
  *
- * @param {Number=} startyear Year to begin data at
- * @param {Number=} endyear Year to begin data at
+ * @param {Number=} startyear first year of data to include
+ * @param {Number=} endyear last year of data to include
  * @returns {Array} longitude - longitude of perihelion from moving equinox
  */
 EarthOrbit.getLongitude = function(startyear = -Infinity, endyear = Infinity) {
@@ -111,12 +113,11 @@ EarthOrbit.getLongitude = function(startyear = -Infinity, endyear = Infinity) {
  * Get obliquity by year. For more information about obliquity, please visit:
  * https://climate.nasa.gov/news/2948/milankovitch-orbital-cycles-and-their-role-in-earths-climate/
  *
- * If a start and end year is provided, only measurements within the given range will be
- * returned.
+ * If ``startyear`` or ``endyear`` is provided, only measurements within the given range will be returned.
  *
- * @param {Number=} startyear Year to begin data at
- * @param {Number=} endyear Year to begin data at
- * @returns {Array} obliquity
+ * @param {Number=} startyear first year of data to include
+ * @param {Number=} endyear last year of data to include
+ * @returns {Array} list of historical obliquity values for each year
  */
 EarthOrbit.getObliquity = function(startyear = -Infinity, endyear = Infinity) {
     return this._dataEccOblLongi
@@ -128,12 +129,11 @@ EarthOrbit.getObliquity = function(startyear = -Infinity, endyear = Infinity) {
  * Get eccentricity by year. For more information about eccentricity, please visit: 
  * https://climate.nasa.gov/news/2948/milankovitch-orbital-cycles-and-their-role-in-earths-climate/
  *
- * If a start and end year is provided, only measurements within the given range will be
- * returned.
+ * If ``startyear`` or ``endyear`` is provided, only measurements within the given range will be returned.
  *
- * @param {Number=} startyear Year to begin data at
- * @param {Number=} endyear Year to begin data at
- * @returns {Array} eccentricity
+ * @param {Number=} startyear first year of data to include
+ * @param {Number=} endyear last year of data to include
+ * @returns {Array} list of historical eccentricity values for each year
  */
 EarthOrbit.getEccentricity = function(startyear = -Infinity, endyear = Infinity) {
     return this._dataEccOblLongi
@@ -144,12 +144,11 @@ EarthOrbit.getEccentricity = function(startyear = -Infinity, endyear = Infinity)
 /**
  * Get insolation by year. Insolation here is the amount of solar radiation received at 65 N in June on Earth.
  *
- * If a start and end year is provided, only measurements within the given range will be
- * returned.
+ * If ``startyear`` or ``endyear`` is provided, only measurements within the given range will be returned.
  *
- * @param {Number=} startyear Year to begin data at
- * @param {Number=} endyear Year to begin data at
- * @returns {Array} insolation
+ * @param {Number=} startyear first year of data to include
+ * @param {Number=} endyear last year of data to include
+ * @returns {Array} list of historical insolation values for each year
  */
 EarthOrbit.getInsolation = function(startyear = -Infinity, endyear = Infinity) {
     return this._dataInsolation
@@ -161,12 +160,11 @@ EarthOrbit.getInsolation = function(startyear = -Infinity, endyear = Infinity) {
  * Get precession by year. For more information about precession, please visit:
  * https://climate.nasa.gov/news/2948/milankovitch-orbital-cycles-and-their-role-in-earths-climate/
  *
- * If a start and end year is provided, only measurements within the given range will be
- * returned.
+ * If ``startyear`` or ``endyear`` is provided, only measurements within the given range will be returned.
  *
- * @param {Number=} startyear Year to begin data at
- * @param {Number=} endyear Year to begin data at
- * @returns {Array} precession
+ * @param {Number=} startyear first year of data to include
+ * @param {Number=} endyear last year of data to include
+ * @returns {Array} list of historical precession values for each year
  */
 EarthOrbit.getPrecession = function(startyear = -Infinity, endyear = Infinity) {
     return this._dataPrecession

--- a/src/server/services/procedures/execute/execute.js
+++ b/src/server/services/procedures/execute/execute.js
@@ -10,6 +10,7 @@ const Execute = {};
  * Execute a function on the NetsBlox server.
  *
  * @param {Function} fn function (ringified blocks) to execute
+ * @returns {Any} return value of ``fn``
  */
 Execute.call = async function(fn) {
     return await fn();

--- a/src/server/services/procedures/geolocation/geolocation.js
+++ b/src/server/services/procedures/geolocation/geolocation.js
@@ -71,7 +71,7 @@ let reverseGeocode = (lat, lon, response, query)=>{
 /**
  * Geolocates the address and returns the coordinates
  * @param {String} address target address
- * @returns {Object}
+ * @returns {Object} structured data representing the location of the address
  */
 GeoLocationRPC.geolocate = function (address) {
     let response = this.response;
@@ -127,7 +127,7 @@ GeoLocationRPC['county*'] = function (latitude, longitude) {
  * @param {Longitude} longitude longitude of the target location
  * @returns {String} state name
  */
-GeoLocationRPC['state*'] = function (latitude, longitude) {
+ GeoLocationRPC['state*'] = function (latitude, longitude) {
     reverseGeocode(latitude, longitude, this.response, '.administrativeLevels.level1long');
     return null;
 };

--- a/src/server/services/procedures/geolocation/geolocation.js
+++ b/src/server/services/procedures/geolocation/geolocation.js
@@ -127,7 +127,7 @@ GeoLocationRPC['county*'] = function (latitude, longitude) {
  * @param {Longitude} longitude longitude of the target location
  * @returns {String} state name
  */
- GeoLocationRPC['state*'] = function (latitude, longitude) {
+GeoLocationRPC['state*'] = function (latitude, longitude) {
     reverseGeocode(latitude, longitude, this.response, '.administrativeLevels.level1long');
     return null;
 };

--- a/src/server/services/procedures/google-maps/google-maps.js
+++ b/src/server/services/procedures/google-maps/google-maps.js
@@ -216,7 +216,7 @@ GoogleMaps.getLongitudeFromX = async function(x){
 /**
  * Convert y value of map image to latitude.
  * @param {Number} y y value of map image
- * @returns {Latitude} Latitude of the y value from the image
+ * @returns {Latitude} Latitude of the ``y`` value from the image
  */
 GoogleMaps.getLatitudeFromY = async function(y){
     const mapInfo = await this._getClientMap(this.caller.clientId);
@@ -227,7 +227,7 @@ GoogleMaps.getLatitudeFromY = async function(y){
 /**
  * Convert x value of map image to longitude.
  * @param {Number} x x value of map image
- * @returns {Longitude} Longitude of the x value from the image
+ * @returns {Longitude} Longitude of the ``x`` value from the image
  *
  * @deprecated
  */
@@ -247,7 +247,7 @@ GoogleMaps.getLatitude = function(y){
 };
 
 /**
- * Get the earth coordinates (latitude, longitude) of a given point in the last requested map image (x, y).
+ * Get the earth coordinates ``[latitude, longitude]`` of a given point in the last requested map image ``[x, y]``.
  * @param {Number} x x position of the point
  * @param {Number} y y position of the point
  * @returns {Array} A list containing the latitude and longitude of the given point.
@@ -261,10 +261,10 @@ GoogleMaps.getEarthCoordinates = function(x, y){
 };
 
 /**
- * Get the image coordinates (x, y) of a given location on the earth (latitude, longitude).
+ * Get the image coordinates ``[x, y]`` of a given location on the earth ``[latitude, longitude]``.
  * @param {Latitude} latitude latitude of the point
  * @param {Longitude} longitude longitude of the point
- * @returns {Array} A list containing (x, y) position of the given point.
+ * @returns {Array} A list containing the ``[x, y]`` position of the given point.
  */
 
 GoogleMaps.getImageCoordinates = function(latitude, longitude){

--- a/src/server/services/procedures/google-streetview/google-streetview.js
+++ b/src/server/services/procedures/google-streetview/google-streetview.js
@@ -18,9 +18,9 @@ ApiConsumer.setRequiredApiKey(GoogleStreetView, GoogleMapsKey);
  * @param {Longitude} longitude Longitude coordinate of location
  * @param {BoundedNumber<1,2000>} width Width of image
  * @param {BoundedNumber<1,2000>} height Height of image
- * @param {BoundedNumber<1,120>} fieldofview Field of View of image, maximum of 120
+ * @param {BoundedNumber<1,120>} fieldofview Field of View of image, maximum of ``120``
  * @param {BoundedNumber<0,360>} heading Heading of view
- * @param {BoundedNumber<-90,90>} pitch Pitch of view, 90 to point up, -90 to point down
+ * @param {BoundedNumber<-90,90>} pitch Pitch of view, ``90`` to point up, ``-90`` to point down
  * @returns {Image} Image of requested location with specified size and orientation
  * @deprecated
  */
@@ -37,9 +37,9 @@ GoogleStreetView.getViewFromLatLong = function(latitude, longitude, width, heigh
  * @param {Longitude} longitude Longitude coordinate of location
  * @param {BoundedNumber<1,2000>} width Width of image
  * @param {BoundedNumber<1,2000>} height Height of image
- * @param {BoundedNumber<1,120>} fieldofview Field of View of image, maximum of 120
+ * @param {BoundedNumber<1,120>} fieldofview Field of View of image, maximum of ``120``
  * @param {BoundedNumber<0,360>} heading Heading of view
- * @param {BoundedNumber<-90,90>} pitch Pitch of view, 90 to point up, -90 to point down
+ * @param {BoundedNumber<-90,90>} pitch Pitch of view, ``90`` to point up, ``-90`` to point down
  * @returns {Image} Image of requested location with specified size and orientation
  */
 GoogleStreetView.getView = function(latitude, longitude, width, height, fieldofview, heading, pitch) {
@@ -55,9 +55,9 @@ GoogleStreetView.getView = function(latitude, longitude, width, height, fieldofv
  * @param {String} location Address or Name of location
  * @param {BoundedNumber<1,2000>} width Width of image
  * @param {BoundedNumber<1,2000>} height Height of image
- * @param {BoundedNumber<1,120>} fieldofview Field of View of image, maximum of 120
+ * @param {BoundedNumber<1,120>} fieldofview Field of View of image, maximum of ``120``
  * @param {BoundedNumber<0,360>} heading Heading of view
- * @param {BoundedNumber<-90,90>} pitch Pitch of view, 90 to point up, -90 to point down
+ * @param {BoundedNumber<-90,90>} pitch Pitch of view, ``90`` to point up, ``-90`` to point down
  * @returns {Image} Image of requested location with specified size and orientation
  */
 GoogleStreetView.getViewFromAddress = function(location, width, height, fieldofview, heading, pitch) {
@@ -70,14 +70,18 @@ GoogleStreetView.getViewFromAddress = function(location, width, height, fieldofv
 
 /**
  * Get Street View metadata of a location using coordinates.
- * Status explanation: "OK": No errors occurred.
- * "ZERO_RESULTS": No image could be found near the provided location.
- * "NOT_FOUND": The location provided could not be found.
+ * 
+ * Status explanation:
+ * 
+ * - ``OK`` - No errors occurred.
+ * - ``ZERO_RESULTS`` - No image could be found near the provided location.
+ * - ``NOT_FOUND`` - The location provided could not be found.
+ * 
  * @param {Latitude} latitude Latitude coordinate of location
  * @param {Longitude} longitude Longitude coordinate of location
- * @param {BoundedNumber<1,120>} fieldofview Field of View of image, maximum of 120
+ * @param {BoundedNumber<1,120>} fieldofview Field of View of image, maximum of ``120``
  * @param {BoundedNumber<0,360>} heading Heading of view
- * @param {BoundedNumber<-90,90>} pitch Pitch of view, 90 to point up, -90 to point down
+ * @param {BoundedNumber<-90,90>} pitch Pitch of view, ``90`` to point up, ``-90`` to point down
  * @returns {Object} Metadata infromation about the requested Street View.
  */
 GoogleStreetView.getInfo = function(latitude, longitude, width, height, fieldofview, heading, pitch) {
@@ -94,13 +98,17 @@ GoogleStreetView.getInfo = function(latitude, longitude, width, height, fieldofv
 
 /**
  * Get Street View metadata of a location using a location query.
- * Status explanation: "OK": No errors occurred.
- * "ZERO_RESULTS": No image could be found near the provided location.
- * "NOT_FOUND": The location provided could not be found.
+ * 
+ * Status explanation:
+ * 
+ * - ``OK`` - No errors occurred.
+ * - ``ZERO_RESULTS`` - No image could be found near the provided location.
+ * - ``NOT_FOUND`` - The location provided could not be found.
+ * 
  * @param {String} location Address or Name of location
- * @param {BoundedNumber<1,120>} fieldofview Field of View of image, maximum of 120
+ * @param {BoundedNumber<1,120>} fieldofview Field of View of image, maximum of ``120``
  * @param {BoundedNumber<0,360>} heading Heading of view
- * @param {BoundedNumber<-90,90>} pitch Pitch of view, 90 to point up, -90 to point down
+ * @param {BoundedNumber<-90,90>} pitch Pitch of view, ``90`` to point up, ``-90`` to point down
  * @returns {Object} Metadata infromation about the requested Street View.
  */
 GoogleStreetView.getInfoFromAddress = function(location, width, height, fieldofview, heading, pitch) {
@@ -119,10 +127,10 @@ GoogleStreetView.getInfoFromAddress = function(location, width, height, fieldofv
  * Check for availability of imagery at a location using coordinates
  * @param {Latitude} latitude Latitude coordinate of location
  * @param {Longitude} longitude Longitude coordinate of location
- * @param {BoundedNumber<1,120>} fieldofview Field of View of image, maximum of 120
+ * @param {BoundedNumber<1,120>} fieldofview Field of View of image, maximum of ``120``
  * @param {BoundedNumber<0,360>} heading Heading of view
- * @param {BoundedNumber<-90,90>} pitch Pitch of view, 90 to point up, -90 to point down
- * @returns {Boolean}
+ * @param {BoundedNumber<-90,90>} pitch Pitch of view, ``90`` to point up, ``-90`` to point down
+ * @returns {Boolean} ``true`` if imagery is available
  */
 GoogleStreetView.isAvailable = function(latitude, longitude, fieldofview, heading, pitch) {
     const key = this.apiKey.value;
@@ -139,10 +147,10 @@ GoogleStreetView.isAvailable = function(latitude, longitude, fieldofview, headin
 /**
  * Check for availability of imagery at a location using an address
  * @param {String} location Address or Name of location
- * @param {BoundedNumber<1,120>} fieldofview Field of View of image, maximum of 120
+ * @param {BoundedNumber<1,120>} fieldofview Field of View of image, maximum of ``120``
  * @param {BoundedNumber<0,360>} heading Heading of view
- * @param {BoundedNumber<-90,90>} pitch Pitch of view, 90 to point up, -90 to point down
- * @returns {Boolean}
+ * @param {BoundedNumber<-90,90>} pitch Pitch of view, ``90`` to point up, ``-90`` to point down
+ * @returns {Boolean} ``true`` if imagery is available
  */
 GoogleStreetView.isAvailableFromAddress = function(location, fieldofview, heading, pitch) {
     const key = this.apiKey.value;

--- a/src/server/services/procedures/historical-temperature/historical-temperature.js
+++ b/src/server/services/procedures/historical-temperature/historical-temperature.js
@@ -1,10 +1,14 @@
 /**
- * Access to Berkeley Earth data
- *
+ * Access to Berkeley Earth data.
  * See http://berkeleyearth.org/data/ for additional details.
  * 
- * Use 'all land' for all land area, 'global' for all surface area,
- * or 'northern hemisphere' and 'southern hemisphere' for the land in those hemispheres.
+ * These RPCs take a ``region`` argument, which can either be a country
+ * or one of the following special values:
+ * 
+ * - ``all land`` - get data for all landmasses around the world
+ * - ``global`` - get data for the entire Earth (including oceans)
+ * - ``northern hemisphere`` - only northern landmasses
+ * - ``southern hemisphere`` - only southern landmasses
  *
  * @service
  * @category Science

--- a/src/server/services/procedures/human-mortality-database/human-mortality-database.js
+++ b/src/server/services/procedures/human-mortality-database/human-mortality-database.js
@@ -180,7 +180,7 @@ const mortality = {};
  *
  * @returns {Array} all available data
  */
-mortality.getAllData = async () => await getData();
+mortality.getAllData = getData;
 
 /**
  * Get a list of all the countries represented in the data.

--- a/src/server/services/procedures/human-mortality-database/human-mortality-database.js
+++ b/src/server/services/procedures/human-mortality-database/human-mortality-database.js
@@ -1,12 +1,12 @@
 /**
  * This service accesses data from the human mortality database which tabulates
  * death rates broken down by age group and gender for various countries.
- *
- * Note: for countries that don't report separate male and female death counts,
- * the gender breakdowns are just the total multiplied by a rough estimate
- * of the percent of people in that country who are male/female.
- *
+ * 
  * For more information, see https://www.mortality.org/.
+ * 
+ * `Note: for countries that don't report separate male and female death counts,
+ * the gender breakdowns are just the total multiplied by a rough estimate
+ * of the percent of people in that country who are male/female.`
  * 
  * @service
  * @category Science
@@ -173,23 +173,20 @@ async function getData() {
 const mortality = {};
 
 /**
- * Get all the mortality data - potentially a lot of data.
- * Only use this if you truly need access to all data.
- * This is an object organized by country, then by date (mm/dd/yyyy), then by gender, then by category.
+ * Get all the mortality data. This is potentially a lot of data.
+ * **Only use this if you truly need access to all data.**
+ * 
+ * This is returned as structured data organized by country, then by date (mm/dd/yyyy), then by gender, then by category.
  *
- * Note: for countries that don't report separate male and female death counts,
- * the gender breakdowns are just the total multiplied by a rough estimate
- * of the percent of people in that country who are male/female.
- *
- * @returns {Array}
+ * @returns {Array} all available data
  */
-mortality.getAllData = getData;
+mortality.getAllData = async () => await getData();
 
 /**
  * Get a list of all the countries represented in the data.
  * These are not the country names, but a unique identifier for them.
  *
- * @returns {Array}
+ * @returns {Array} the requested data
  */
 mortality.getCountries = async function() {
     return Object.keys(await getData());
@@ -198,27 +195,23 @@ mortality.getCountries = async function() {
  * Get a list of all the valid genders represented in the data.
  * These can be used in a query.
  *
- * @returns {Array}
+ * @returns {Array} the requested data
  */
 mortality.getGenders = () => GENDERS;
 /**
  * Get a list of all the categories represented in the data.
  * These can be used in a query.
  *
- * @returns {Array}
+ * @returns {Array} the requested data
  */
 mortality.getCategories = () => CATEGORIES;
 
 /**
  * Get all the data associated with the given country.
  * This is an object organized by year, then by week, then broken down by gender.
- *
- * Note: for countries that don't report separate male and female death counts,
- * the gender breakdowns are just the total multiplied by a rough estimate
- * of the percent of people in that country who are male/female.
  * 
  * @param {String} country Name of the country to look up
- * @returns {Array}
+ * @returns {Array} the requested data
  */
 mortality.getAllDataForCountry = async function(country) {
     const res = (await getData())[country];
@@ -230,14 +223,10 @@ mortality.getAllDataForCountry = async function(country) {
  * Get the time series data for the given country, filtered to the specified gender and category
  * in month/day/year format.
  *
- * Note: for countries that don't report separate male and female death counts,
- * the gender breakdowns are just the total multiplied by a rough estimate
- * of the percent of people in that country who are male/female.
- *
- * @param {String} country Name of the country to look up
- * @param {Enum<male,female,both>=} gender Gender group for filtering. Defaults to 'both'.
- * @param {MortalityCategory=} category Category for filtering. Defaults to 'deaths total'.
- * @returns {Array}
+ * @param {String} country name of the country to look up
+ * @param {Enum<male,female,both>=} gender gender group for filtering. Defaults to ``both``.
+ * @param {MortalityCategory=} category category for filtering. Defaults to ``deaths total``.
+ * @returns {Array} the requested data
  */
 mortality.getTimeSeries = async function(country, gender='both', category='deaths total') {
     const countryData = await this.getAllDataForCountry(country);

--- a/src/server/services/procedures/ice-core-data/ice-core-data.js
+++ b/src/server/services/procedures/ice-core-data/ice-core-data.js
@@ -2,19 +2,20 @@
  * Access to NOAA Paleoclimatology ice core data.
  *
  * For more information, check out
- * https://www.ncdc.noaa.gov/data-access/paleoclimatology-data/datasets/ice-core
+ * https://www.ncdc.noaa.gov/data-access/paleoclimatology-data/datasets/ice-core.
  *
- * Original datasets are available at
- * https://www1.ncdc.noaa.gov/pub/data/paleo/icecore/antarctica/antarctica2015co2composite.txt
- * https://www1.ncdc.noaa.gov/pub/data/paleo/icecore/antarctica/antarctica2015co2law.txt
- * https://www1.ncdc.noaa.gov/pub/data/paleo/icecore/antarctica/antarctica2015co2wais.txt
- * https://www1.ncdc.noaa.gov/pub/data/paleo/icecore/antarctica/vostok/co2nat.txt
- * https://www1.ncdc.noaa.gov/pub/data/paleo/icecore/antarctica/vostok/deutnat.txt
- * https://www1.ncdc.noaa.gov/pub/data/paleo/icecore/antarctica/epica_domec/edc3deuttemp2007.txt
- * https://www1.ncdc.noaa.gov/pub/data/paleo/icecore/greenland/summit/grip/isotopes/gripd18o.txt
- * https://www1.ncdc.noaa.gov/pub/data/paleo/icecore/antarctica/vostok/gt4nat.txt
- * https://www1.ncdc.noaa.gov/pub/data/paleo/icecore/antarctica/law/law2012d18o.txt
- * https://www1.ncdc.noaa.gov/pub/data/paleo/icecore/antarctica/wdc05a2013d18o.txt
+ * Original datasets are available at:
+ * 
+ * - https://www1.ncdc.noaa.gov/pub/data/paleo/icecore/antarctica/antarctica2015co2composite.txt
+ * - https://www1.ncdc.noaa.gov/pub/data/paleo/icecore/antarctica/antarctica2015co2law.txt
+ * - https://www1.ncdc.noaa.gov/pub/data/paleo/icecore/antarctica/antarctica2015co2wais.txt
+ * - https://www1.ncdc.noaa.gov/pub/data/paleo/icecore/antarctica/vostok/co2nat.txt
+ * - https://www1.ncdc.noaa.gov/pub/data/paleo/icecore/antarctica/vostok/deutnat.txt
+ * - https://www1.ncdc.noaa.gov/pub/data/paleo/icecore/antarctica/epica_domec/edc3deuttemp2007.txt
+ * - https://www1.ncdc.noaa.gov/pub/data/paleo/icecore/greenland/summit/grip/isotopes/gripd18o.txt
+ * - https://www1.ncdc.noaa.gov/pub/data/paleo/icecore/antarctica/vostok/gt4nat.txt
+ * - https://www1.ncdc.noaa.gov/pub/data/paleo/icecore/antarctica/law/law2012d18o.txt
+ * - https://www1.ncdc.noaa.gov/pub/data/paleo/icecore/antarctica/wdc05a2013d18o.txt
  *
  * @service
  * @category Science
@@ -187,7 +188,7 @@ IceCoreData._getColumnData = async function(core, datatype, startyear, endyear) 
 
 /**
  * Get names of ice cores with data available.
- * @returns {Array}
+ * @returns {Array<String>} list of ice core names
  */
 IceCoreData.getIceCoreNames = function() {
     return Object.keys(IceCoreData._coreMetadata); 
@@ -196,7 +197,7 @@ IceCoreData.getIceCoreNames = function() {
 /**
  * Get a table showing the amount of available data for each ice core.
  *
- * @returns {Array}
+ * @returns {Table} data availability table
  */
 IceCoreData.getDataAvailability = async function() {
     const dataStatistics = await IceCoreMetadata.find({}).lean();
@@ -236,13 +237,13 @@ IceCoreData.getDataAvailability = async function() {
 /**
  * Get CO2 in ppm (parts per million) by year from the ice core.
  *
- * If a start and end year is provided, only measurements within the given range will be
- * returned.
+ * If ``startyear`` or ``endyear`` is provided, only measurements within the given range will be returned.
  *
  * @param {String} core Core to get data from
- * @param {Number=} startyear Year to begin data at
- * @param {Number=} endyear Year to begin data at
- * @returns {Array}
+ * @param {Number=} startyear first year of data to include
+ * @param {Number=} endyear last year of data to include
+ * 
+ * @returns {Array} the requested data
  */
 IceCoreData.getCarbonDioxideData = function(core, startyear, endyear){
     return IceCoreData._getColumnData(core, 'Carbon Dioxide', startyear, endyear);
@@ -251,13 +252,13 @@ IceCoreData.getCarbonDioxideData = function(core, startyear, endyear){
 /**
  * Get delta-O-18 in per mil (parts per thousand) by year from the ice core.
  *
- * If a start and end year is provided, only measurements within the given range will be
- * returned.
+ * If ``startyear`` or ``endyear`` is provided, only measurements within the given range will be returned.
  *
  * @param {String} core Ice core to get data from
- * @param {Number=} startyear
- * @param {Number=} endyear
- * @returns {Array}
+ * @param {Number=} startyear first year of data to include
+ * @param {Number=} endyear last year of data to include
+ * 
+ * @returns {Array} the requested data
  */
 IceCoreData.getDelta18OData = function(core, startyear, endyear){
     return IceCoreData._getColumnData(core, 'Delta18O', startyear, endyear);
@@ -266,13 +267,13 @@ IceCoreData.getDelta18OData = function(core, startyear, endyear){
 /**
  * Get deuterium in per mil (parts per thousand) by year from the ice core.
  *
- * If a start and end year is provided, only measurements within the given range will be
- * returned.
+ * If ``startyear`` or ``endyear`` is provided, only measurements within the given range will be returned.
  *
  * @param {String} core Ice core to get data from
- * @param {Number=} startyear
- * @param {Number=} endyear
- * @returns {Array}
+ * @param {Number=} startyear first year of data to include
+ * @param {Number=} endyear last year of data to include
+ * 
+ * @returns {Array} the requested data
  */
 IceCoreData.getDeuteriumData = function(core, startyear, endyear){
     return IceCoreData._getColumnData(core, 'Deuterium', startyear, endyear);
@@ -281,13 +282,13 @@ IceCoreData.getDeuteriumData = function(core, startyear, endyear){
 /**
  * Get temperature difference in Celsius by year from the ice core.
  *
- * If a start and end year is provided, only measurements within the given range will be
- * returned.
+ * If ``startyear`` or ``endyear`` is provided, only measurements within the given range will be returned.
  *
  * @param {String} core Ice core to get data from
- * @param {Number=} startyear
- * @param {Number=} endyear
- * @returns {Array}
+ * @param {Number=} startyear first year of data to include
+ * @param {Number=} endyear last year of data to include
+ * 
+ * @returns {Array} the requested data
  */
 IceCoreData.getTemperatureData = function(core, startyear, endyear){
     return IceCoreData._getColumnData(core, 'Temperature', startyear, endyear);
@@ -297,6 +298,8 @@ IceCoreData.getTemperatureData = function(core, startyear, endyear){
  * Get metadata about an ice core including statistics about the available data.
  *
  * @param {String} core Name of core to get metadata of
+ * 
+ * @returns {Object} ice core metadata
  */
 IceCoreData.getIceCoreMetadata = async function(core){
     validateIceCore(core);

--- a/src/server/services/procedures/iex-trading/iex-trading.js
+++ b/src/server/services/procedures/iex-trading/iex-trading.js
@@ -128,7 +128,7 @@ StockConsumer.dailyPercentChange = function(companySymbol) {
  * Get historical closing price information about the specified company
  * @param {String} companySymbol Company stock ticker symbol
  * @param {String} range Time period (e.g. 1m, 3m, 1y, etc) to retrieve prices for
- * @returns {Array} Historical price information
+ * @returns {Array} A list of pairs of ``[date, closingPrice]`` representing historical price information
  */
 StockConsumer.historicalClosingPrices = function(companySymbol, range) {
     companySymbol = companySymbol.toUpperCase();

--- a/src/server/services/procedures/key-value-store/key-value-store.js
+++ b/src/server/services/procedures/key-value-store/key-value-store.js
@@ -76,9 +76,10 @@ const formatChildKeys = function(key, data) {
 const KeyValueStore = {};
 
 /**
- * Get the stored value
+ * Get the stored value for a key.
  * @param {String} key Fetch value for the given key
  * @param {String=} password Password (if password-protected)
+ * @returns {Any} the stored value
  */
 KeyValueStore.get = async function(key, password) {
     const keys = getKeys(key);
@@ -108,7 +109,7 @@ KeyValueStore.get = async function(key, password) {
 };
 
 /**
- * Set the stored value
+ * Set the stored value for a key.
  * @param {String} key Key to use for retrieving the variable
  * @param {Any} value Value to associated with key
  * @param {String=} password Password (if password-protected)
@@ -145,7 +146,7 @@ KeyValueStore.put = async function(key, value, password) {
 };
 
 /**
- * Delete the stored value
+ * Delete the stored value for a key.
  * @param {String} key Key to remove from store
  * @param {String=} password Password (if password-protected)
  */
@@ -175,7 +176,8 @@ KeyValueStore.delete = async function(key, password) {
 
 /**
  * Get the ID of the parent key.
- * @param {String} key
+ * @param {String} key key to get the parent of
+ * @returns {String} the parent key
  */
 KeyValueStore.parent = function(key) {
     var keys = getKeys(key);
@@ -191,6 +193,7 @@ KeyValueStore.parent = function(key) {
  * Get the IDs of the child keys.
  * @param {String} key
  * @param {String=} password Password (if password-protected)
+ * @returns {Array<String>} list of child key ids
  */
 KeyValueStore.child = async function(key, password) {
     let result = await getStore();

--- a/src/server/services/procedures/mauna-loa-co2-data/mauna-loa-co2-data.js
+++ b/src/server/services/procedures/mauna-loa-co2-data/mauna-loa-co2-data.js
@@ -27,11 +27,10 @@ MaunaLoaCO2Data.serviceName = 'MaunaLoaCO2Data';
  * Get the mole fraction of CO2 (in parts per million) by year. Missing measurements
  * are interpolated.
  *
- * If a start and end year is provided, only measurements within the given range will be
- * returned.
+ * If ``startyear`` or ``endyear`` is provided, only measurements within the given range will be returned.
  *
- * @param {Number=} startyear Year to begin data at
- * @param {Number=} endyear Year to begin data at
+ * @param {Number=} startyear first year of data to include
+ * @param {Number=} endyear last year of data to include
  * @returns {Array}
  */
 MaunaLoaCO2Data.getRawCO2 = function(startyear=-Infinity, endyear=Infinity){
@@ -43,11 +42,10 @@ MaunaLoaCO2Data.getRawCO2 = function(startyear=-Infinity, endyear=Infinity){
  * Get the mole fraction of CO2 (in parts per million) by year with the seasonal
  * cycle removed.
  *
- * If a start and end year is provided, only measurements within the given range will be
- * returned.
+ * If ``startyear`` or ``endyear`` is provided, only measurements within the given range will be returned.
  *
- * @param {Number=} startyear Year to begin data at
- * @param {Number=} endyear Year to begin data at
+ * @param {Number=} startyear first year of data to include
+ * @param {Number=} endyear last year of data to include
  * @returns {Array}
  */
 MaunaLoaCO2Data.getCO2Trend = function(startyear=-Infinity, endyear=Infinity){

--- a/src/server/services/procedures/movie-db/movie-db.js
+++ b/src/server/services/procedures/movie-db/movie-db.js
@@ -200,37 +200,44 @@ MovieDB.searchPerson = async function(name) {
 /**
  * Get the image path for a given movie backdrop.
  *
+ * @category Movies
  * @param {String} id Movie ID
+ * @returns {String} the image path
  */
 MovieDB.movieBackdropPath = function(id) { return movieInfo.call(this, id, 'backdrop_path'); };
 
 /**
  * Get the budget for a given movie.
  *
+ * @category Movies
  * @param {String} id Movie ID
  */
 MovieDB.movieBudget = function(id) { return movieInfo.call(this, id, 'budget'); };
 /**
  * Get the genres of a given movie.
  *
+ * @category Movies
  * @param {String} id Movie ID
  */
 MovieDB.movieGenres = function(id) { return movieInfo.call(this, id, 'genres'); };
 /**
  * Get the original language of a given movie.
  *
+ * @category Movies
  * @param {String} id Movie ID
  */
 MovieDB.movieOriginalLanguage = function(id) { return movieInfo.call(this, id, 'original_language'); };
 /**
  * Get the original title of a given movie.
  *
+ * @category Movies
  * @param {String} id Movie ID
  */
 MovieDB.movieOriginalTitle = function(id) { return movieInfo.call(this, id, 'original_title'); };
 /**
  * Get an overview for a given movie.
  *
+ * @category Movies
  * @param {String} id Movie ID
  */
 MovieDB.movieOverview = function(id) { return movieInfo.call(this, id, 'overview'); };
@@ -239,72 +246,84 @@ MovieDB.movieOverview = function(id) { return movieInfo.call(this, id, 'overview
  *
  * For more information, check out https://developers.themoviedb.org/3/getting-started/popularity
  *
+ * @category Movies
  * @param {String} id Movie ID
  */
 MovieDB.moviePopularity = function(id) { return movieInfo.call(this, id, 'popularity'); };
 /**
  * Get the poster path for a given movie.
  *
+ * @category Movies
  * @param {String} id Movie ID
  */
 MovieDB.moviePosterPath = function(id) { return movieInfo.call(this, id, 'poster_path'); };
 /**
  * Get the production companies for a given movie.
  *
+ * @category Movies
  * @param {String} id Movie ID
  */
 MovieDB.movieProductionCompanies = function(id) { return movieInfo.call(this, id, 'production_companies'); };
 /**
  * Get the countries in which a given movie was produced.
  *
+ * @category Movies
  * @param {String} id Movie ID
  */
 MovieDB.movieProductionCountries = function(id) { return movieInfo.call(this, id, 'production_countries'); };
 /**
  * Get the release data for a given movie.
  *
+ * @category Movies
  * @param {String} id Movie ID
  */
 MovieDB.movieReleaseDate = function(id) { return movieInfo.call(this, id, 'release_date'); };
 /**
  * Get the revenue for a given movie.
  *
+ * @category Movies
  * @param {String} id Movie ID
  */
 MovieDB.movieRevenue = function(id) { return movieInfo.call(this, id, 'revenue'); };
 /**
  * Get the runtime for a given movie.
  *
+ * @category Movies
  * @param {String} id Movie ID
  */
 MovieDB.movieRuntime = function(id) { return movieInfo.call(this, id, 'runtime'); };
 /**
  * Get the spoken languages for a given movie.
  *
+ * @category Movies
  * @param {String} id Movie ID
  */
 MovieDB.movieSpokenLanguages = function(id) { return movieInfo.call(this, id, 'spoken_languages'); };
 /**
  * Get the tagline for a given movie.
  *
+ * @category Movies
  * @param {String} id Movie ID
  */
 MovieDB.movieTagline = function(id) { return movieInfo.call(this, id, 'tagline'); };
 /**
  * Get the title for a given movie.
  *
+ * @category Movies
  * @param {String} id Movie ID
  */
 MovieDB.movieTitle = function(id) { return movieInfo.call(this, id, 'title'); };
 /**
  * Get the average vote for a given movie.
  *
+ * @category Movies
  * @param {String} id Movie ID
  */
 MovieDB.movieVoteAverage = function(id) { return movieInfo.call(this, id, 'vote_average'); };
 /**
  * Get the vote count for a given movie.
  *
+ * @category Movies
  * @param {String} id Movie ID
  */
 MovieDB.movieVoteCount = function(id) { return movieInfo.call(this, id, 'vote_count'); };
@@ -312,36 +331,42 @@ MovieDB.movieVoteCount = function(id) { return movieInfo.call(this, id, 'vote_co
 /**
  * Get the biography for a given person.
  *
+ * @category People
  * @param {String} id Person ID
  */
 MovieDB.personBiography = function(id) { return personInfo.call(this, id, 'biography'); };
 /**
  * Get the birthday of a given person.
  *
+ * @category People
  * @param {String} id Person ID
  */
 MovieDB.personBirthday = function(id) { return personInfo.call(this, id, 'birthday'); };
 /**
  * Get the death date of a given person.
  *
+ * @category People
  * @param {String} id Person ID
  */
 MovieDB.personDeathday = function(id) { return personInfo.call(this, id, 'deathday'); };
 /**
  * Get the gender of a given person.
  *
+ * @category People
  * @param {String} id Person ID
  */
 MovieDB.personGender = function(id) { return personInfo.call(this, id, 'gender'); };
 /**
  * Get the name of a given person.
  *
+ * @category People
  * @param {String} id Person ID
  */
 MovieDB.personName = function(id) { return personInfo.call(this, id, 'name'); };
 /**
  * Get the place of birth for a given person.
  *
+ * @category People
  * @param {String} id Person ID
  */
 MovieDB.personPlaceOfBirth = function(id) { return personInfo.call(this, id, 'place_of_birth'); };
@@ -350,12 +375,14 @@ MovieDB.personPlaceOfBirth = function(id) { return personInfo.call(this, id, 'pl
  *
  * For more information, check out https://developers.themoviedb.org/3/getting-started/popularity
  *
+ * @category People
  * @param {String} id Person ID
  */
 MovieDB.personPopularity = function(id) { return personInfo.call(this, id, 'popularity'); };
 /**
  * Get the profile path for a given person.
  *
+ * @category People
  * @param {String} id Person ID
  */
 MovieDB.personProfilePath = function(id) { return personInfo.call(this, id, 'profile_path'); };
@@ -363,48 +390,56 @@ MovieDB.personProfilePath = function(id) { return personInfo.call(this, id, 'pro
 /**
  * Get the cast characters for a given movie.
  *
+ * @category Movies
  * @param {String} id Movie ID
  */
 MovieDB.movieCastCharacters = function(id) { return movieCredits.call(this, id, 'cast', 'character'); };
 /**
  * Get the cast names for a given movie.
  *
+ * @category Movies
  * @param {String} id Movie ID
  */
 MovieDB.movieCastNames = function(id) { return movieCredits.call(this, id, 'cast', 'name'); };
 /**
  * Get the cast IDs for a given movie.
  *
+ * @category Movies
  * @param {String} id Movie ID
  */
 MovieDB.movieCastPersonIDs = function(id) { return movieCredits.call(this, id, 'cast', 'id'); };
 /**
  * Get the cast profile paths for a given movie.
  *
+ * @category Movies
  * @param {String} id Movie ID
  */
 MovieDB.movieCastProfilePaths = function(id) { return movieCredits.call(this, id, 'cast', 'profile_path'); };
 /**
  * Get the crew names for a given movie.
  *
+ * @category Movies
  * @param {String} id Movie ID
  */
 MovieDB.movieCrewNames = function(id) { return movieCredits.call(this, id, 'crew', 'name'); };
 /**
  * Get the crew jobs for a given movie.
  *
+ * @category Movies
  * @param {String} id Movie ID
  */
 MovieDB.movieCrewJobs = function(id) { return movieCredits.call(this, id, 'crew', 'job'); };
 /**
  * Get the crew IDs for a given movie.
  *
+ * @category Movies
  * @param {String} id Movie ID
  */
 MovieDB.movieCrewPersonIDs = function(id) { return movieCredits.call(this, id, 'crew', 'id'); };
 /**
  * Get the crew profile paths for a given movie.
  *
+ * @category Movies
  * @param {String} id Movie ID
  */
 MovieDB.movieCrewProfilePaths = function(id) { return movieCredits.call(this, id, 'crew', 'profile_path'); };
@@ -412,30 +447,35 @@ MovieDB.movieCrewProfilePaths = function(id) { return movieCredits.call(this, id
 /**
  * Get the image paths for a given person.
  *
+ * @category People
  * @param {String} id Person ID
  */
 MovieDB.personImageFilePaths = function(id) { return personImages.call(this, id, 'profiles', 'file_path'); };
 /**
  * Get the image aspect ratios for a given person.
  *
+ * @category People
  * @param {String} id Person ID
  */
 MovieDB.personImageAspectRatios = function(id) { return personImages.call(this, id, 'profiles', 'aspect_ratio'); };
 /**
  * Get the image heights for a given person.
  *
+ * @category People
  * @param {String} id Person ID
  */
 MovieDB.personImageHeights = function(id) { return personImages.call(this, id, 'profiles', 'height'); };
 /**
  * Get the image widths for a given person.
  *
+ * @category People
  * @param {String} id Person ID
  */
 MovieDB.personImageWidths = function(id) { return personImages.call(this, id, 'profiles', 'width'); };
 /**
  * Get the image vote counts for a given person.
  *
+ * @category People
  * @param {String} id Person ID
  */
 MovieDB.personImageVoteCounts = function(id) { return personImages.call(this, id, 'profiles', 'vote_count'); };
@@ -443,72 +483,84 @@ MovieDB.personImageVoteCounts = function(id) { return personImages.call(this, id
 /**
  * Get the characters played by a given person.
  *
+ * @category People
  * @param {String} id Person ID
  */
 MovieDB.personCastCharacters = function(id) { return personCredits.call(this, id, 'cast', 'character'); };
 /**
  * Get the movies in which a given person was cast.
  *
+ * @category People
  * @param {String} id Person ID
  */
 MovieDB.personCastMovieIDs = function(id) { return personCredits.call(this, id, 'cast', 'id'); };
 /**
  * Get the original titles in which a given person was cast.
  *
+ * @category People
  * @param {String} id Person ID
  */
 MovieDB.personCastOriginalTitles = function(id) { return personCredits.call(this, id, 'cast', 'original_title'); };
 /**
  * Get the cast poster paths for a given person.
  *
+ * @category People
  * @param {String} id Person ID
  */
 MovieDB.personCastPosterPaths = function(id) { return personCredits.call(this, id, 'cast', 'poster_path'); };
 /**
  * Get the cast release dates for a given person.
  *
+ * @category People
  * @param {String} id Person ID
  */
 MovieDB.personCastReleaseDates = function(id) { return personCredits.call(this, id, 'cast', 'release_date'); };
 /**
  * Get the cast titles for a given person.
  *
+ * @category People
  * @param {String} id Person ID
  */
 MovieDB.personCastTitles = function(id) { return personCredits.call(this, id, 'cast', 'title'); };
 /**
  * Get the movie IDs for which a given person was a member of the crew.
  *
+ * @category People
  * @param {String} id Person ID
  */
 MovieDB.personCrewMovieIDs = function(id) { return personCredits.call(this, id, 'crew', 'id'); };
 /**
  * Get the crew jobs for a given person.
  *
+ * @category People
  * @param {String} id Person ID
  */
 MovieDB.personCrewJobs = function(id) { return personCredits.call(this, id, 'crew', 'job'); };
 /**
  * Get the original titles for which a given person was a member of the crew.
  *
+ * @category People
  * @param {String} id Person ID
  */
 MovieDB.personCrewOriginalTitles = function(id) { return personCredits.call(this, id, 'crew', 'original_title'); };
 /**
  * Get the poster paths for movies in which a given person was a member of the crew.
  *
+ * @category People
  * @param {String} id Person ID
  */
 MovieDB.personCrewPosterPaths = function(id) { return personCredits.call(this, id, 'crew', 'poster_path'); };
 /**
  * Get the release dates for movies in which a given person was a member of the crew.
  *
+ * @category People
  * @param {String} id Person ID
  */
 MovieDB.personCrewReleaseDates = function(id) { return personCredits.call(this, id, 'crew', 'release_date'); };
 /**
  * Get the crew titles for a given person.
  *
+ * @category People
  * @param {String} id Person ID
  */
 MovieDB.personCrewTitles = function(id) { return personCredits.call(this, id, 'crew', 'title'); };
@@ -516,7 +568,8 @@ MovieDB.personCrewTitles = function(id) { return personCredits.call(this, id, 'c
 /**
  * Get an image from a path.
  *
- * @param {String} path
+ * @param {String} path location of the image
+ * @returns {Image} the requested image
  */
 MovieDB.getImage = function(path){
     return this._sendImage({path});

--- a/src/server/services/procedures/n-player/n-player.js
+++ b/src/server/services/procedures/n-player/n-player.js
@@ -30,6 +30,7 @@ const NPlayer = function() {
 
 /**
  * Start a new turn-based game.
+ * @returns {Boolean} ``true`` on successful start
  */
 NPlayer.prototype.start = async function() {
     this._state.players = await Utils.getRoleIds(this.caller.projectId);
@@ -45,6 +46,7 @@ NPlayer.prototype.start = async function() {
 
 /**
  * Get the number of detected players in the game.
+ * @returns {Number} number of players
  */
 NPlayer.prototype.getN = function() {
     return this._state.players.length;
@@ -52,6 +54,7 @@ NPlayer.prototype.getN = function() {
 
 /**
  * Get the player whose turn it currently is.
+ * @returns {String} role id of the active player, or empty string if there are no players
  */
 NPlayer.prototype.getActive = function() {
     if(this._state.players.length === 0) {
@@ -63,6 +66,7 @@ NPlayer.prototype.getActive = function() {
 
 /**
  * Get the player who played last.
+ * @returns {String} role id of the previous player, or empty string if no previous player
  */
 NPlayer.prototype.getPrevious = function() {
     if(this._state.previous == null || this._state.players.length == 0) {
@@ -74,6 +78,7 @@ NPlayer.prototype.getPrevious = function() {
 
 /**
  * Get the player who will be active next.
+ * @returns {String} role id of the next player, or empty string if there are no players
  */
 NPlayer.prototype.getNext = function() {
     if(this._state.players.length == 0) {

--- a/src/server/services/procedures/new-york-public-library/new-york-public-library.js
+++ b/src/server/services/procedures/new-york-public-library/new-york-public-library.js
@@ -17,12 +17,22 @@ function listify(item) {
 
 /**
  * Search the New York Public Library collection and return matching items.
- * Search results are arranged in pages - only one page is returned each call.
+ * Because there may be many matching items, search results are arranged in pages.
+ * You can specify the number of items in each page and the page number to retrieve.
+ * 
+ * This returns a list of up to ``perPage`` matches.
+ * Each item in the list is structured data containing details about the object.
+ * This includes:
+ * 
+ * - ``uuid`` - a general identifier for the object, needed for :func:`NewYorkPublicLibrary.getDetails`
+ * - ``itemID`` - another identifier, needed for :func:`NewYorkPublicLibrary.getImage`
+ * - ``title`` - the title of the object
+ * - ``dateDigitized`` - a timestamp of when the object was added to the database
  * 
  * @param {String} term Search term
  * @param {BoundedNumber<1,1000>=} perPage Maximum number of items in a page of results (default 50)
  * @param {BoundedNumber<1>=} page Page number of results to get (default 1)
- * @returns {Array} Up to perPage matching objects
+ * @returns {Array<Object>} An list of up to ``perPage`` matching objects
  */
 NYPL.search = async function(term, perPage = 50, page = 1) {
     if (page <= 0) page = 1;
@@ -62,6 +72,7 @@ NYPL._getPath = function(obj, path, default_val) {
 
 /**
  * Get details about the item.
+ * This requires the ``uuid`` for the object, which can be retrieved from :func:`NewYorkPublicLibrary.search`.
  * 
  * @param {String} uuid uuid of the object
  * @returns {Array} Item details
@@ -123,8 +134,10 @@ NYPL._pickImageURL = function(urls) {
 
 /**
  * Get an image of the object.
+ * This requires the ``itemID`` for the object, which can be retrieved from :func:`NewYorkPublicLibrary.search`.
  * 
  * @param {String} itemID itemID of the object
+ * @returns {Image} An image of the object, if one is available
  */
 NYPL.getImage = function(itemID) {
     return this._getImageURLs(itemID).then(urls => urls.length == 0 ? '' : this._sendImage({url:this._pickImageURL(urls)})).catch(() => '');

--- a/src/server/services/procedures/ocean-data/ocean-data.js
+++ b/src/server/services/procedures/ocean-data/ocean-data.js
@@ -3,6 +3,7 @@
  * temperature and sea level.
  *
  * For more information, check out:
+ * 
  * - http://www.columbia.edu/~mhs119/Sensitivity+SL+CO2/
  * - https://www.paleo.bristol.ac.uk/~ggdjl/warm_climates/hansen_etal.pdf.
  *
@@ -16,9 +17,11 @@ OceanData._data = require('./data');
 /**
  * Get historical oxygen isotope ratio values by year.
  *
+ * If ``startYear`` or ``endYear`` is provided, only measurements within the given range will be returned.
+ * 
  * @param {Number=} startYear earliest year to include in results
  * @param {Number=} endYear latest year to include in results
- * @returns {Array} ratios - a list of oxygen isotope ratios by year
+ * @returns {Array} a list of oxygen isotope ratios by year
  */
 OceanData.getOxygenRatio = function(startYear = -Infinity, endYear = Infinity){
     return this._data
@@ -29,9 +32,11 @@ OceanData.getOxygenRatio = function(startYear = -Infinity, endYear = Infinity){
 /**
  * Get historical deep ocean temperatures in Celsius by year.
  *
+ * If ``startYear`` or ``endYear`` is provided, only measurements within the given range will be returned.
+ * 
  * @param {Number=} startYear earliest year to include in results
  * @param {Number=} endYear latest year to include in results
- * @returns {Array} temperatures - a list of deep ocean temperatures by year
+ * @returns {Array} a list of deep ocean temperatures by year
  */
 OceanData.getDeepOceanTemp = function(startYear = -Infinity, endYear = Infinity){
     return this._data
@@ -42,9 +47,11 @@ OceanData.getDeepOceanTemp = function(startYear = -Infinity, endYear = Infinity)
 /**
  * Get historical surface ocean temperatures in Celsius by year.
  *
+ * If ``startYear`` or ``endYear`` is provided, only measurements within the given range will be returned.
+ * 
  * @param {Number=} startYear earliest year to include in results
  * @param {Number=} endYear latest year to include in results
- * @returns {Array} temperatures - a list of surface ocean temperatures by year
+ * @returns {Array} a list of surface ocean temperatures by year
  */
 OceanData.getSurfaceTemp = function(startYear = -Infinity, endYear = Infinity){
     return this._data
@@ -55,9 +62,11 @@ OceanData.getSurfaceTemp = function(startYear = -Infinity, endYear = Infinity){
 /**
  * Get historical sea level in meters by year.
  *
+ * If ``startYear`` or ``endYear`` is provided, only measurements within the given range will be returned.
+ * 
  * @param {Number=} startYear earliest year to include in results
  * @param {Number=} endYear latest year to include in results
- * @returns {Array} meters - change in sea level (in meters) by year
+ * @returns {Array} a list of change in sea level (in meters) by year
  */
 OceanData.getSeaLevel = function(startYear = -Infinity, endYear = Infinity){
     return this._data

--- a/src/server/services/procedures/paleocean-oxygen-isotopes/paleocean-oxygen-isotopes.js
+++ b/src/server/services/procedures/paleocean-oxygen-isotopes/paleocean-oxygen-isotopes.js
@@ -4,12 +4,14 @@
  * For more information, check out
  * https://www.ncdc.noaa.gov/paleo-search/study/5847
  *
- * Original datasets are available at
- * https://www1.ncdc.noaa.gov/pub/data/paleo/contributions_by_author/lisiecki2005/lisiecki2005.txt
+ * Original datasets are available at:
+ * https://www1.ncdc.noaa.gov/pub/data/paleo/contributions_by_author/lisiecki2005/lisiecki2005.txt.
+ * 
  * @service
  * @category Science
  * @category Climate
  */
+
 const fs = require('fs');
 const path = require('path');
 const assert = require('assert');
@@ -55,12 +57,11 @@ PaleoceanOxygenIsotopes._dataSedim = fs.readFileSync(path.join(__dirname, 'Sedim
  * refer to isotopic ratios and calculated by calculating the ratio of isotopic concentrations in 
  * a sample and in a standard, subtracting one and multiplying by one thousand).
  *
- * If a start and end year is provided, only measurements within the given range will be
- * returned.
+ * If ``startyear`` or ``endyear`` is provided, only measurements within the given range will be returned.
  *
- * @param {Number=} startyear Year to begin data at
- * @param {Number=} endyear Year to begin data at
- * @returns {Array} delta 18O
+ * @param {Number=} startyear first year of data to include
+ * @param {Number=} endyear least year of data to include
+ * @returns {Array} a list of delta 18O values by year
  */
 PaleoceanOxygenIsotopes.getDelta18O = function(startyear = -Infinity, endyear = Infinity) {
     return this._dataDelta18O
@@ -71,12 +72,11 @@ PaleoceanOxygenIsotopes.getDelta18O = function(startyear = -Infinity, endyear = 
 /**
  * Get delta 18O error value (unit: per mill).
  *
- * If a start and end year is provided, only measurements within the given range will be
- * returned.
+ * If ``startyear`` or ``endyear`` is provided, only measurements within the given range will be returned.
  *
- * @param {Number=} startyear Year to begin data at
- * @param {Number=} endyear Year to begin data at
- * @returns {Array} delta 18O error
+ * @param {Number=} startyear first year of data to include
+ * @param {Number=} endyear least year of data to include
+ * @returns {Array} a list of delta 18O error values by year
  */
 PaleoceanOxygenIsotopes.getDelta18OError = function(startyear = -Infinity, endyear = Infinity) {
     return this._dataDelta18O
@@ -87,12 +87,11 @@ PaleoceanOxygenIsotopes.getDelta18OError = function(startyear = -Infinity, endye
 /**
  * Get average sedimentation rate value (unit: centimeter per kiloyear).
  *
- * If a start and end year is provided, only measurements within the given range will be
- * returned.
+ * If ``startyear`` or ``endyear`` is provided, only measurements within the given range will be returned.
  *
- * @param {Number=} startyear Year to begin data at
- * @param {Number=} endyear Year to begin data at
- * @returns {Array} average sedimentation rate
+ * @param {Number=} startyear first year of data to include
+ * @param {Number=} endyear least year of data to include
+ * @returns {Array} a list of average sedimentation rate by year
  */
 PaleoceanOxygenIsotopes.getAverageSedimentationRates = function(startyear = -Infinity, endyear = Infinity) {
     return this._dataSedim
@@ -103,12 +102,11 @@ PaleoceanOxygenIsotopes.getAverageSedimentationRates = function(startyear = -Inf
 /**
  * Get normalized sedimentation rate value (unit: dimensionless).
  *
- * If a start and end year is provided, only measurements within the given range will be
- * returned.
+ * If ``startyear`` or ``endyear`` is provided, only measurements within the given range will be returned.
  *
- * @param {Number=} startyear Year to begin data at
- * @param {Number=} endyear Year to begin data at
- * @returns {Array} normalized sedimentation rate
+ * @param {Number=} startyear first year of data to include
+ * @param {Number=} endyear least year of data to include
+ * @returns {Array} a list of normalized sedimentation rate by year
  */
 PaleoceanOxygenIsotopes.getNormalizedSedimentationRates = function(startyear = -Infinity, endyear = Infinity) {
     return this._dataSedim

--- a/src/server/services/procedures/paralleldots/paralleldots.js
+++ b/src/server/services/procedures/paralleldots/paralleldots.js
@@ -41,8 +41,11 @@ ParallelDots._parallelDotsRequest = async function(path, text){
 
 /**
  * Find the overall sentiment of the given text along with the confidence score.
+ * The returned structured data hasa confidence level for each of the following sentiment categories:
+ * ``negative``, ``neutral``, and ``positive``.
  *
- * @param {String} text
+ * @param {String} text text to analyze
+ * @returns {Object} structured data with confidence level for each category
  */
 ParallelDots.getSentiment = async function(text) {
     const result = await this._parallelDotsRequest('/sentiment', text);
@@ -50,10 +53,12 @@ ParallelDots.getSentiment = async function(text) {
 };
 
 /**
- * Find the similarity between two snippets of text.
- *
- * @param {String} text1 Long text (more than 2 words)
- * @param {String} text2 Long text (more than 2 words)
+ * Get the level of similarity between two snippets of text.
+ * Note that the two pieces of text should be long, like full sentences (not just 2 words).
+ * 
+ * @param {String} text1 the first piece of text
+ * @param {String} text2 a second piece of text
+ * @returns {BoundedNumber<0,1>} the computed similarity level
  */
 ParallelDots.getSimilarity = async function(text1, text2) {
     const body = `api_key=${this.apiKey.value}&text_1=${encodeURIComponent(text1)}&text_2=${encodeURIComponent(text2)}`;
@@ -69,7 +74,8 @@ ParallelDots.getSimilarity = async function(text1, text2) {
 /**
  * Identify named entities in the given text.
  *
- * @param {String} text
+ * @param {String} text text to analyze
+ * @returns {Array} speculated information about named entities in the text, including the confidence level
  */
 ParallelDots.getNamedEntities = async function(text) {
     const result = await this._parallelDotsRequest('/ner', text);
@@ -79,7 +85,8 @@ ParallelDots.getNamedEntities = async function(text) {
 /**
  * Extract keywords from the given text along with their confidence score.
  *
- * @param {String} text
+ * @param {String} text text to analyze
+ * @returns {Array} information about keywords in the text
  */
 ParallelDots.getKeywords = async function(text) {
     const result = await this._parallelDotsRequest('/keywords', text);
@@ -92,7 +99,8 @@ ParallelDots.getKeywords = async function(text) {
  * For more information about IAB categories, see
  * https://www.iab.com/guidelines/iab-quality-assurance-guidelines-qag-taxonomy/
  *
- * @param {String} text
+ * @param {String} text text to analyze
+ * @returns {Array} information about the category breakdown, along with confidence scores
  */
 ParallelDots.getTaxonomy = async function(text) {
     const result = await this._parallelDotsRequest('/taxonomy', text);
@@ -101,8 +109,11 @@ ParallelDots.getTaxonomy = async function(text) {
 
 /**
  * Find the emotion in the given text.
+ * This is returned as structured data containing confidence levels for each of the following emotions:
+ * ``excited``, ``angry``, ``bored``, ``fear``, ``sad``, and ``happy``.
  *
- * @param {String} text
+ * @param {String} text text to analyze
+ * @returns {Object} structured data with confidence levels for each emotion
  */
 ParallelDots.getEmotion = async function(text) {
     const result = await this._parallelDotsRequest('/emotion', text);
@@ -112,7 +123,8 @@ ParallelDots.getEmotion = async function(text) {
 /**
  * Compute the probability of sarcasm for the given text.
  *
- * @param {String} text
+ * @param {String} text text to analyze
+ * @returns {BoundedNumber<0,1>} predicted likelihood that the text is sarcastic
  */
 ParallelDots.getSarcasmProbability = async function(text) {
     const result = await this._parallelDotsRequest('/sarcasm', text);
@@ -121,8 +133,11 @@ ParallelDots.getSarcasmProbability = async function(text) {
 
 /**
  * Get the intent of the given text along with the confidence score.
+ * This is returned as structed data with confidence levels for each of the following intents:
+ * ``news``, ``query``, ``spam``, ``marketing``, and ``feedback``.
  *
- * @param {String} text
+ * @param {String} text text to analyze
+ * @returns {Object} structed data with confidence levels for each intent
  */
 ParallelDots.getIntent = async function(text) {
     const result = await this._parallelDotsRequest('/intent', text);
@@ -130,9 +145,11 @@ ParallelDots.getIntent = async function(text) {
 };
 
 /**
- * Classify the given text as abuse, hate speech, or neither.
- *
- * @param {String} text
+ * Classify the given text as ``abusive``, ``hate_speech``, or ``neither``.
+ * The returned structured data has confidence levels for each of these categories.
+ * 
+ * @param {String} text text to analyze
+ * @returns {Object} structured data containing the confidence levels
  */
 ParallelDots.getAbuse = function(text) {
     return this._parallelDotsRequest('/abuse', text);

--- a/src/server/services/procedures/phone-iot/phone-iot.js
+++ b/src/server/services/procedures/phone-iot/phone-iot.js
@@ -1,15 +1,15 @@
 /**
- * PhoneIoT is a service in `NetsBlox <https://netsblox.org/>`_ that's meant to teach Internet of Things (IoT) topics as early as K-12 education.
+ * PhoneIoT is a service in `NetsBlox <https://netsblox.org/>`__ that's meant to teach Internet of Things (IoT) topics as early as K-12 education.
  * It allows you to programmatically access your smartphone's sensors and display.
  * This includes accessing hardware sensors such as the accelerometer, gyroscope, microphone, camera, and many others depending on the device.
  * PhoneIoT also allows you to control a customizable interactive display, enabling you to use your device as a custom remote control, or even create and run distributed (multiplayer) applications.
  * The limits are up to your imagination!
  * 
- * To get started using PhoneIoT, download the PhoneIoT app on your mobile device, available for `Android <https://play.google.com/store/apps/details?id=org.netsblox.phoneiot>`_ and iOS (`coming soon`), and then go to the `NetsBlox editor <https://editor.NetsBlox.org>`_.
+ * To get started using PhoneIoT, download the PhoneIoT app on your mobile device, available for `Android <https://play.google.com/store/apps/details?id=org.netsblox.phoneiot>`__ and iOS (*coming soon*), and then go to the `NetsBlox editor <https://editor.NetsBlox.org>`__.
  * In the top left of the editor, you should see a grid of several colored tabs.
  * Under the ``Network`` tab, grab a ``call`` block and place it in the center script area.
  * Click the first dropdown on the ``call`` block and select the ``PhoneIoT`` service.
- * The second dropdown selects the specific `Remote Procedure Call` (RPC) to execute - see the table of contents  for information about the various RPCs.
+ * The second dropdown selects the specific *Remote Procedure Call* (RPC) to execute - see the table of contents  for information about the various RPCs.
  * 
  * Inside the PhoneIoT app on your mobile device, click the button at the top left to open the menu, and then click ``connect``.
  * If you successfully connected, you should get a small popup message at the bottom of the screen.
@@ -195,7 +195,7 @@ PhoneIoT.prototype.getColor = function (red, green, blue, alpha = 255) {
  * This can be used to get the total acceleration from the accelerometer (which gives a vector).
  * 
  * @category Utility
- * @param {List} vec the vector value
+ * @param {Array<Number>} vec the vector value
  * @returns {Number} magnitude of the vector (a non-negative number)
  */
 PhoneIoT.prototype.magnitude = function(vec) { return common.magnitude(vec); };
@@ -204,8 +204,8 @@ PhoneIoT.prototype.magnitude = function(vec) { return common.magnitude(vec); };
  * This is identical to dividing each component by the magnitude.
  * 
  * @category Utility
- * @param {List} vec the vector value
- * @returns {List} the normalized vector
+ * @param {Array<Number>} vec the vector value
+ * @returns {Array<Number>} the normalized vector
  */
 PhoneIoT.prototype.normalize = function(vec) { return common.normalize(vec); };
 
@@ -510,7 +510,7 @@ if (PHONE_IOT_MODE === 'native' || PHONE_IOT_MODE === 'both') {
         return this._passToDevice('authenticate', arguments);
     };
     /**
-     * This RPC requests that you receive any events from the `Graphical User Interface` (GUI) on the phone's display.
+     * This RPC requests that you receive any events from the *Graphical User Interface* (GUI) on the phone's display.
      * This is needed to receive any type of GUI event, including button clicks, joystick movements, and textbox update events.
      * You only need to call this RPC once, which you can do at the start of your program (but after calling :func:`PhoneIoT.setCredentials`).
      * 
@@ -600,7 +600,7 @@ if (PHONE_IOT_MODE === 'native' || PHONE_IOT_MODE === 'both') {
         return Object.keys(common.SENSOR_PACKERS);
     };
     /**
-     * This is the first RPC you should `always` call when working with PhoneIoT.
+     * This is the first RPC you should *always* call when working with PhoneIoT.
      * It sets the login credentials (password) to use for all future interactions with the device.
      * 
      * @param {Device} device id of the device

--- a/src/server/services/procedures/pixabay/pixabay.js
+++ b/src/server/services/procedures/pixabay/pixabay.js
@@ -53,30 +53,40 @@ pixabay._encodeQueryOptions = function(keywords, type, minHeight=0, self) {
 
 
 /**
- * Search Pixabay for a photo matching the keywords
+ * Search Pixabay for a photo matching the keywords.
+ * This is identical to :func:`Pixabay.searchAll` except that only photos are returned.
+ * 
  * @param {String} keywords Search query
- * @param {Number=} maxHeight Restrict query to images smaller than "maxHeight"
- * @param {Number=} minHeight Restrict query to images larger than "minHeight"
+ * @param {Number=} maxHeight Restrict query to images smaller than ``maxHeight``
+ * @param {Number=} minHeight Restrict query to images larger than ``minHeight``
+ * @returns {Array<Object>} list of matching images
  */
 pixabay.searchPhoto = function (keywords, maxHeight, minHeight) {
     return this._sendStruct(this._encodeQueryOptions(keywords, null, minHeight, 'searchPhoto'), parserFnGen(maxHeight));
 };
 
 /**
- * Search Pixabay for an illustration matching the keywords
+ * Search Pixabay for an illustration matching the keywords.
+ * This is identical to :func:`Pixabay.searchAll` except that only illustrations are returned.
+ * 
  * @param {String} keywords Search query
- * @param {Number=} maxHeight Restrict query to images smaller than "maxHeight"
- * @param {Number=} minHeight Restrict query to images larger than "minHeight"
+ * @param {Number=} maxHeight Restrict query to images smaller than ``maxHeight``
+ * @param {Number=} minHeight Restrict query to images larger than ``minHeight``
+ * @returns {Array<Object>} list of matching images
  */
 pixabay.searchIllustration = function (keywords, maxHeight, minHeight) {
     return this._sendStruct(this._encodeQueryOptions(keywords, null, minHeight, 'searchIllustration'), parserFnGen(maxHeight));
 };
 
 /**
- * Search Pixabay for an image matching the keywords
+ * Search Pixabay for an image matching the keywords.
+ * The returned data is a list of structeud data objects containing information about each matching image.
+ * Notably, the ``image_url`` field of each match can be passed to :func:`Pixabay.getImage`.
+ * 
  * @param {String} keywords Search query
- * @param {Number=} maxHeight Restrict query to images smaller than "maxHeight"
- * @param {Number=} minHeight Restrict query to images larger than "minHeight"
+ * @param {Number=} maxHeight Restrict query to images smaller than ``maxHeight``
+ * @param {Number=} minHeight Restrict query to images larger than ``minHeight``
+ * @returns {Array<Object>} list of matching images
  */
 pixabay.searchAll = function (keywords, maxHeight, minHeight) {
     return this._sendStruct(this._encodeQueryOptions(keywords, null, minHeight, 'searchAll'), parserFnGen(maxHeight));
@@ -84,7 +94,9 @@ pixabay.searchAll = function (keywords, maxHeight, minHeight) {
 
 /**
  * Retrieve an image from Pixabay from the URL
+ * 
  * @param {String} url URL of the image to retrieve
+ * @returns {Image} the requested image
  */
 pixabay.getImage = function(url){
     return this._sendImage({url});

--- a/src/server/services/procedures/public-roles/public-roles.js
+++ b/src/server/services/procedures/public-roles/public-roles.js
@@ -12,6 +12,8 @@ const PublicRoles = {};
 
 /**
  * Get the public role ID for the current role.
+ * 
+ * @returns {String} the public role id
  */
 PublicRoles.getPublicRoleId = function() {
     const {projectId, roleId, clientId} = this.caller;

--- a/src/server/services/procedures/roboscape/roboscape.js
+++ b/src/server/services/procedures/roboscape/roboscape.js
@@ -204,8 +204,8 @@ if (ROBOSCAPE_MODE === 'native' || ROBOSCAPE_MODE === 'both') {
     /**
      * Returns true if the given robot is alive, sent messages in the
      * last two seconds.
-     * @param {string} robot name of the robot (matches at the end)
-     * @returns {boolean} True if the robot is alive
+     * @param {String} robot name of the robot (matches at the end)
+     * @returns {Boolean} ``true`` if the robot is alive
      */
     RoboScape.prototype.isAlive = function (robot) {
         return this._passToRobot('isAlive', arguments);
@@ -213,10 +213,10 @@ if (ROBOSCAPE_MODE === 'native' || ROBOSCAPE_MODE === 'both') {
 
     /**
      * Sets the wheel speed of the given robots.
-     * @param {string} robot name of the robot (matches at the end)
-     * @param {number} left speed of the left wheel in [-128, 128]
-     * @param {number} right speed of the right wheel in [-128, 128]
-     * @returns {boolean} True if the robot was found
+     * @param {String} robot name of the robot (matches at the end)
+     * @param {Number} left speed of the left wheel in ``[-128, 128]``
+     * @param {Number} right speed of the right wheel in ``[-128, 128]``
+     * @returns {Boolean} ``true`` if the robot was found
      */
     RoboScape.prototype.setSpeed = function (robot, left, right) {
         return this._passToRobot('setSpeed', arguments);
@@ -224,10 +224,10 @@ if (ROBOSCAPE_MODE === 'native' || ROBOSCAPE_MODE === 'both') {
 
     /**
      * Sets one of the LEDs of the given robots.
-     * @param {string} robot name of the robot (matches at the end)
-     * @param {number} led the number of the LED (0 or 1)
-     * @param {number} command false/off/0, true/on/1, or toggle/2
-     * @returns {boolean} True if the robot was found
+     * @param {String} robot name of the robot (matches at the end)
+     * @param {Number} led the number of the LED (0 or 1)
+     * @param {Number} command false/off/0, true/on/1, or toggle/2
+     * @returns {Boolean} ``true`` if the robot was found
      */
     RoboScape.prototype.setLed = function (robot, led, command) {
         return this._passToRobot('setLed', arguments);
@@ -235,10 +235,10 @@ if (ROBOSCAPE_MODE === 'native' || ROBOSCAPE_MODE === 'both') {
 
     /**
      * Beeps with the speaker.
-     * @param {string} robot name of the robot (matches at the end)
-     * @param {number} msec duration in milliseconds
-     * @param {number} tone frequency of the beep in Hz
-     * @returns {boolean} True if the robot was found
+     * @param {String} robot name of the robot (matches at the end)
+     * @param {Number} msec duration in milliseconds
+     * @param {Number} tone frequency of the beep in Hz
+     * @returns {Boolean} ``true`` if the robot was found
      */
     RoboScape.prototype.beep = function (robot, msec, tone) {
         return this._passToRobot('beep', arguments);
@@ -246,10 +246,10 @@ if (ROBOSCAPE_MODE === 'native' || ROBOSCAPE_MODE === 'both') {
 
     /**
      * Turns on the infra red LED.
-     * @param {string} robot name of the robot (matches at the end)
-     * @param {number} msec duration in milliseconds between 0 and 1000
-     * @param {number} pwr power level between 0 and 100
-     * @returns {boolean} True if the robot was found
+     * @param {String} robot name of the robot (matches at the end)
+     * @param {BoundedNumber<0,1000>} msec duration in milliseconds
+     * @param {BoundedNumber<0,100>} pwr power level
+     * @returns {Boolean} ``true`` if the robot was found
      */
     RoboScape.prototype.infraLight = function (robot, msec, pwr) {
         return this._passToRobot('infraLight', arguments);
@@ -257,8 +257,8 @@ if (ROBOSCAPE_MODE === 'native' || ROBOSCAPE_MODE === 'both') {
 
     /**
      * Ranges with the ultrasound sensor
-     * @param {string} robot name of the robot (matches at the end)
-     * @returns {number} range in centimeters
+     * @param {String} robot name of the robot (matches at the end)
+     * @returns {Number} range in centimeters
      */
     RoboScape.prototype.getRange = function (robot) {
         return this._passToRobot('getRange', arguments);
@@ -266,7 +266,7 @@ if (ROBOSCAPE_MODE === 'native' || ROBOSCAPE_MODE === 'both') {
 
     /**
      * Returns the current number of wheel ticks (1/64th rotations)
-     * @param {string} robot name of the robot (matches at the end)
+     * @param {String} robot name of the robot (matches at the end)
      * @returns {array} the number of ticks for the left and right wheels
      */
     RoboScape.prototype.getTicks = function (robot) {
@@ -275,10 +275,10 @@ if (ROBOSCAPE_MODE === 'native' || ROBOSCAPE_MODE === 'both') {
 
     /**
      * Drives the whiles for the specified ticks.
-     * @param {string} robot name of the robot (matches at the end)
-     * @param {number} left distance for left wheel in ticks
-     * @param {number} right distance for right wheel in ticks
-     * @returns {boolean} True if the robot was found
+     * @param {String} robot name of the robot (matches at the end)
+     * @param {Number} left distance for left wheel in ticks
+     * @param {Number} right distance for right wheel in ticks
+     * @returns {Boolean} ``true`` if the robot was found
      */
     RoboScape.prototype.drive = function (robot, left, right) {
         return this._passToRobot('drive', arguments);
@@ -286,9 +286,9 @@ if (ROBOSCAPE_MODE === 'native' || ROBOSCAPE_MODE === 'both') {
 
     /**
      * Sets the total message limit for the given robot.
-     * @param {string} robot name of the robot (matches at the end)
-     * @param {number} rate number of messages per seconds
-     * @returns {boolean} True if the robot was found
+     * @param {String} robot name of the robot (matches at the end)
+     * @param {Number} rate number of messages per seconds
+     * @returns {Boolean} ``true`` if the robot was found
      */
     RoboScape.prototype.setTotalRate = function (robot, rate) {
         return this._passToRobot('setTotalRate', arguments);
@@ -296,10 +296,10 @@ if (ROBOSCAPE_MODE === 'native' || ROBOSCAPE_MODE === 'both') {
 
     /**
      * Sets the client message limit and penalty for the given robot.
-     * @param {string} robot name of the robot (matches at the end)
-     * @param {number} rate number of messages per seconds
-     * @param {number} penalty number seconds of penalty if rate is violated
-     * @returns {boolean} True if the robot was found
+     * @param {String} robot name of the robot (matches at the end)
+     * @param {Number} rate number of messages per seconds
+     * @param {Number} penalty number seconds of penalty if rate is violated
+     * @returns {Boolean} ``true`` if the robot was found
      */
     RoboScape.prototype.setClientRate = function (robot, rate, penalty) {
         return this._passToRobot('setClientRate', arguments);
@@ -310,9 +310,9 @@ if (ROBOSCAPE_MODE === 'native' || ROBOSCAPE_MODE === 'both') {
 if (ROBOSCAPE_MODE === 'security' || ROBOSCAPE_MODE === 'both') {
     /**
      * Sends a textual command to the robot
-     * @param {string} robot name of the robot (matches at the end)
-     * @param {string} command textual command
-     * @returns {string} textual response
+     * @param {String} robot name of the robot (matches at the end)
+     * @param {String} command textual command
+     * @returns {String} textual response
      */
     RoboScape.prototype.send = async function (robot, command) {
         robot = await this._getRobot(robot);

--- a/src/server/services/procedures/service-creation/service-creation.js
+++ b/src/server/services/procedures/service-creation/service-creation.js
@@ -257,7 +257,7 @@ const getBlockArgs = blockXml => {
  *
  * @param {String} name Service name
  * @param {Array} data 2D list of data
- * @param {Object=} options Options (for details, check out `getCreateFromTableOptions`)
+ * @param {Object=} options Options (for details, check out :func:`ServiceCreation.getCreateFromTableOptions`)
  */
 ServiceCreation.createServiceFromTable = async function(name, data, options) {
     ensureLoggedIn(this.caller);

--- a/src/server/services/procedures/simple-hangman/simple-hangman.js
+++ b/src/server/services/procedures/simple-hangman/simple-hangman.js
@@ -39,6 +39,7 @@ var SimpleHangman = function() {
 /**
  * Restart the current game.
  * @param {String=} word New word to guess
+ * @returns {Boolean} ``true`` on successful restart
  */
 SimpleHangman.prototype.restart = function(word) {
     this._reset(word);
@@ -47,6 +48,7 @@ SimpleHangman.prototype.restart = function(word) {
 
 /**
  * Get the current word with where unknown letters are replaced with "_".
+ * @returns {String} current word with blanks
  */
 SimpleHangman.prototype.getCurrentlyKnownWord = function() {
     var letters = this._state.word.split('').map(() => '_');
@@ -79,6 +81,7 @@ SimpleHangman.prototype.guess = function(letter) {
 
 /**
  * Check if the current word has been guessed correctly.
+ * @returns {Boolean} ``true`` if word was guessed correctly
  */
 SimpleHangman.prototype.isWordGuessed = function() {
     var isComplete = this._state.word.length === this._state.knownIndices.length;
@@ -87,6 +90,7 @@ SimpleHangman.prototype.isWordGuessed = function() {
 
 /**
  * Get the current number of incorrect guesses.
+ * @returns {Number} number of wrong guesses
  */
 SimpleHangman.prototype.getWrongCount = function() {
     logger.trace('wrong count is '+this._state.wrongGuesses);
@@ -94,9 +98,7 @@ SimpleHangman.prototype.getWrongCount = function() {
 };
 
 /**
- * Get a new random word
- *
- * @return {undefined}
+ * Get a new random word.
  */
 SimpleHangman.prototype._reset = function(word) {
     if (!word) {

--- a/src/server/services/procedures/smithsonian/smithsonian.js
+++ b/src/server/services/procedures/smithsonian/smithsonian.js
@@ -63,10 +63,28 @@ Smithsonian._raw_search = async function(term, count, skip) {
 };
 
 /**
- * Search and return up to count matching items
+ * Search and return a list of up to ``count`` items that match the search ``term``.
+ * Because there may be a large number of matching items, you can also provide a number of items to ``skip``.
+ * 
+ * Each item in the returned array is structured data about that matching item.
+ * The fields for this data include:
+ * 
+ * - ``id`` - the id of the matching item, needed by :func:`Smithsonian.getImage`.
+ * - ``title`` - the title/name of the matching item
+ * - ``types`` - a list of categories the item falls under (e.g., ``Vases``, ``Paintings``)
+ * - ``authors`` - a list of authors/creators of the item or digitized version
+ * - ``topics`` - a list of topic names for the item (e.g., ``Anthropology``, ``Ethnology``)
+ * - ``notes`` - a list of extra notes about the object, in no particular organization
+ * - ``physicalDescription`` - a list of pairs of ``[label, content]`` regarding the physical description of the object
+ * - ``sources`` - a list of pairs of ``[label, content]`` describing the source of the item or digitization
+ * - ``hasImage`` - ``true`` if the image is listed as having image content in the database. Only items with this field being ``true`` can expect :func:`Smithsonian.getImage` to succeed.
+ * 
+ * If you would like to search for only items which have image content available,
+ * you can perform manual filtering on the ``hasImage`` field of the results,
+ * or you can use :func:`Smithsonian.searchImageContent`, which does the same thing for you.
  * 
  * @param {String} term Term to search for
- * @param {BoundedNumber<1,1000>=} count Maximum number of items to return
+ * @param {BoundedNumber<1,1000>=} count Maximum number of items to return (default 100)
  * @param {BoundedNumber<0>=} skip Number of items to skip from beginning
  * @returns {Array} Up to count matches
  */
@@ -88,7 +106,11 @@ Smithsonian._raw_filter = async function(term, count, skip) {
 };
 
 /**
- * Search and return up to count matching items (only ones with images)
+ * Equivalent to :func:`Smithsonian.search` except that only images with image content (``hasImage = true``) are returned.
+ * 
+ * The filtering of returned matches is done after pulling data from the database.
+ * Thus, you should treat ``count`` as the max number of *unfiltered* items to return,
+ * and similarly ``skip`` as the number of *unfiltered* items to skip.
  * 
  * @param {String} term Term to search for
  * @param {BoundedNumber<1,1000>=} count Maximum number of items to return
@@ -145,9 +167,11 @@ Smithsonian._getImageURLs = function(id) {
 };
 
 /**
- * Get an image associated with the given object
+ * Get an image associated with the given object, if available.
+ * This requires the ``id`` of the object, as provided by :func:`Smithsonian.search` or :func:`Smithsonian.searchImageContent`.
  * 
- * @param {String} id ID of an object returned from search
+ * @param {String} id id of the object
+ * @returns {Image} an image of the object
  */
 Smithsonian.getImage = function(id) {
     return this._getImageURLs(id).then(urls => urls.length == 0 ? '' : this._sendImage({url:urls[0]})).catch(() => '');

--- a/src/server/services/procedures/this-x-does-not-exist/this-x-does-not-exist.js
+++ b/src/server/services/procedures/this-x-does-not-exist/this-x-does-not-exist.js
@@ -32,6 +32,8 @@ TXDNE._getX = async function(rsp, url) {
 
 /**
  * Gets an image of a person that does not exist
+ * 
+ * @returns {Image} a random image of the given type
  */
 TXDNE.getPerson = function() {
     return TXDNE._getX(this.response, 'http://www.thispersondoesnotexist.com/image');
@@ -39,6 +41,8 @@ TXDNE.getPerson = function() {
 
 /**
  * Gets an image of a cat that does not exist
+ * 
+ * @returns {Image} a random image of the given type
  */
 TXDNE.getCat = function() {
     return TXDNE._getX(this.response, 'http://www.thiscatdoesnotexist.com');
@@ -46,6 +50,8 @@ TXDNE.getCat = function() {
 
 /**
  * Gets an image of a horse that does not exist
+ * 
+ * @returns {Image} a random image of the given type
  */
 TXDNE.getHorse = function() {
     return TXDNE._getX(this.response, 'http://www.thishorsedoesnotexist.com');
@@ -53,6 +59,8 @@ TXDNE.getHorse = function() {
 
 /**
  * Gets an image of an artwork that does not exist
+ * 
+ * @returns {Image} a random image of the given type
  */
 TXDNE.getArtwork = function() {
     return TXDNE._getX(this.response, 'https://thisartworkdoesnotexist.com');
@@ -60,6 +68,8 @@ TXDNE.getArtwork = function() {
 
 /**
  * Gets an image of a waifu that does not exist
+ * 
+ * @returns {Image} a random image of the given type
  */
 TXDNE.getWaifu = function() {
     const r = Math.floor(Math.random() * 100000);
@@ -68,6 +78,8 @@ TXDNE.getWaifu = function() {
 
 /**
  * Gets an image of a fursona that does not exist
+ * 
+ * @returns {Image} a random image of the given type
  */
 TXDNE.getFursona = function() {
     const r = String(Math.floor(Math.random() * 100000)).padStart(5, '0');
@@ -76,6 +88,8 @@ TXDNE.getFursona = function() {
 
 /**
  * Gets an image of a pony that does not exist
+ * 
+ * @returns {Image} a random image of the given type
  */
 TXDNE.getPony = function() {
     const r = String(Math.floor(Math.random() * 100000)).padStart(5, '0');
@@ -84,6 +98,8 @@ TXDNE.getPony = function() {
 
 /**
  * Gets an image of a home interior that does not exist
+ * 
+ * @returns {Image} a random image of the given type
  */
 TXDNE.getHomeInterior = function() {
     const options = ['hero', 'img1', 'img2', 'img3', 'img4'];
@@ -93,6 +109,8 @@ TXDNE.getHomeInterior = function() {
 
 /**
  * Gets an image of a congress person that does not exist
+ * 
+ * @returns {Image} a random image of the given type
  */
 TXDNE.getCongressPerson = function() {
     const r = String(Math.floor(Math.random() * 651)).padStart(5, '0');

--- a/src/server/services/procedures/trivia/trivia.js
+++ b/src/server/services/procedures/trivia/trivia.js
@@ -13,7 +13,7 @@ const Trivia = new ApiConsumer('Trivia', 'http://jservice.io/api',{cache: {ttl: 
 /**
  * Get a random trivia question.
  * This includes the question, answer, and additional information.
- * @returns {Promise<Object>}
+ * @returns {Object} structured data representing the trivia question
  */
 Trivia.getRandomQuestion = function() {
     const keepKeys = [
@@ -42,7 +42,7 @@ Trivia.getRandomQuestion = function() {
 /**
  * Get random trivia question.
  * @deprecated
- * @returns {Promise<String>}
+ * @returns {String}
  */
 Trivia.random = function() {
     return this._requestData({path: '/random'})

--- a/src/server/services/procedures/twenty-questions/twenty-questions.js
+++ b/src/server/services/procedures/twenty-questions/twenty-questions.js
@@ -41,6 +41,7 @@ TwentyQuestions.prototype._ensureCallerIsGuesser = function () {
  * Start a new game of twenty questions.
  *
  * @param {String} answer The word or phrase to guess
+ * @returns {Boolean} ``true`` on successful start
  */
 TwentyQuestions.prototype.start = function (answer) {
     this._ensureGameStarted(false);
@@ -57,7 +58,8 @@ TwentyQuestions.prototype.start = function (answer) {
 /**
  * Guess the word or phrase.
  *
- * @param {String} guess word or phrase
+ * @param {String} guess word or phrase to guess
+ * @returns {Boolean} ``true`` if the guess was correct, otherwise ``false``
  */
 TwentyQuestions.prototype.guess = function(guess) {
     this._ensureGameStarted();
@@ -66,9 +68,10 @@ TwentyQuestions.prototype.guess = function(guess) {
     // split the guess
     var correct = false;
     var attempt = guess.toLowerCase().split(/[\s\?]+/);
-    for (var i = 0; i < attempt.length && !correct; i++) {
+    for (var i = 0; i < attempt.length; i++) {
         if (attempt[i] === this._state.correctAnswer) {
             correct = true;
+            break;
         }
     }
 
@@ -87,7 +90,7 @@ TwentyQuestions.prototype.guess = function(guess) {
             content.guess = guess;
             this.socket.sendMessageToRoom('EndGuesserTurn', content);
         }
-        return correct;
+        return false;
     }
     // correct guess, end the game
     content.GuesserWin = true;
@@ -119,6 +122,7 @@ TwentyQuestions.prototype.answer = function(answer) {
 
 /**
  * Check if the game has been started.
+ * @returns {Boolean} ``true`` if the game has started
  */
 TwentyQuestions.prototype.gameStarted = function() {
     return this._state.started;

--- a/src/server/services/services-worker.js
+++ b/src/server/services/services-worker.js
@@ -169,6 +169,7 @@ class ServicesWorker {
         serviceDoc.rawDescription = service._docs.rawDescription;
         serviceDoc.categories = service._docs.categories;
         serviceDoc.servicePath = service._docs.servicePath;
+        serviceDoc.tags = service._docs.tags;
         return serviceDoc;
     }
 


### PR DESCRIPTION
This PR changes a bunch of files, but they're almost exclusively docstring changes.

I went through all the services and updated their docs to make them more informative and look better when viewed in the compiled html version. This includes updating/adding descriptions for RPCs, params, and return values, as well as adding types (only return types, I think, were missing). I also added more cross-referencing between rpcs (in the same service) where appropriate.

I cleaned up a bunch of the custom rst we have from the migrated wiki docs, including changing all (named) links to anonymous links, and using `*...*` instead of `` `...` `` for italics (latter is apparently platform-specific).

I noticed `MovieDB` had a *ton* of RPCs, so I split them into two categories: `Movies` and `People`. We might want to refine this at some point, but it's at least not a breaking change since it only affects the drop down display.

I fixed some rpc param types which were using the wrong casing version (e.g., `string -> String`).

I noticed docs were being generated for a service that was marked as deprecated, so I added the `tags` field to jsdoc metadata and added another (default) filter to ignore deprecated services. Also, I fixed a bug in the html doc gen where it was creating default rpc category rst files wrong (it had `>>>SERV<<<` instead of `>>>RPCS<<<`).

Also I fixed a bug that showed up in the `Geolocation` service where `jsdoc-extractor` wasn't extracting metadata for rpcs that were added with the indexing syntax: `ServiceName['rpcName'] = function ...`.