### PR TITLE
3106 Automatically generate API key documentation for Services

### DIFF
--- a/src/server/docs/adv/rpc-support.rst
+++ b/src/server/docs/adv/rpc-support.rst
@@ -12,16 +12,17 @@ For example, ``The Movie Database`` is set using ``TMDB_API_KEY``.
 Required Environment Variables for RPCs
 ---------------------------------------
 
-- :doc:`/services/AirQuality/index` - ``AIR_NOW_KEY`` API key: `AirNow <https://www.airnow.gov/>`__
-- :doc:`/services/Geolocation/index` - uses the same ``GOOGLE_MAPS_KEY``
-- :doc:`/services/GoogleMaps/index` - ``GOOGLE_MAPS_KEY`` API key: `Google Static Maps <https://developers.google.com/maps/documentation/maps-static/get-api-key#get_key>`__
-- :doc:`/services/MovieDB/index` - ``TMDB_API_KEY`` API key: `The Movie Database <https://developers.themoviedb.org/3/getting-started/introduction>`__
-- :doc:`/services/NASA/index` - ``NASA_KEY`` API key: `NASA <https://api.nasa.gov/>`__
-- :doc:`/services/ParallelDots/index` - ``PARALLELDOTS_KEY`` API key: `Parallel Dots <https://www.paralleldots.com/text-analysis-apis>`__
-- :doc:`/services/Pixabay/index` - ``PIXABAY`` API key: `Pixabay <https://pixabay.com/api/docs/#api_key>`__
-- :doc:`/services/Traffic/index` - ``BING_TRAFFIC_KEY`` API key: `Bing Traffic <https://docs.microsoft.com/en-us/bingmaps/getting-started/bing-maps-dev-center-help/getting-a-bing-maps-key>`__
-- :doc:`/services/Translation/index` - ``AZURE_TRANSLATION_KEY`` API key: `Azure Translation <https://azure.microsoft.com/en-us/services/cognitive-services/translator-text-api/>`__
-- :doc:`/services/Twitter/index` - ``TWITTER_BEARER_TOKEN`` API key: `Twitter <https://developer.twitter.com/en/docs/basics/authentication/oauth-2-0>`__
-- :doc:`/services/Weather/index` - ``OPEN_WEATHER_MAP_KEY`` API key: `OpenWeatherMap <https://openweathermap.org/api>`__
+.. list-table::
+    :header-rows: 1
+
+    * - Service
+      - Environment Variable
+      - Provider
+<% for (const serviceName of Object.keys(apiKeys).filter(s => apiKeys[s]).sort()) { %>
+<% const key = apiKeys[serviceName]; %>
+    * - :doc:`/services/<%= serviceName %>/index`
+      - ``<%= key.envVar %>``
+      - `<%= key.provider %> <<%= key.helpUrl %>>`__
+<% } %>
 
 To simplify this process (and to keep your ``~/.bashrc`` clean), these values can be stored in a ``.env`` file in the project root directory and they will be loaded into the environment on starting NetsBlox.

--- a/src/server/docs/index.rst
+++ b/src/server/docs/index.rst
@@ -13,7 +13,7 @@ NetsBlox Documentation
     fundamentals/howto.rst
     fundamentals/handling-errors.rst
 
->>>SERV<<<
+<%= services %>
 
 .. toctree::
     :maxdepth: 2

--- a/src/server/services/procedures/autograders/docs/index.rst
+++ b/src/server/services/procedures/autograders/docs/index.rst
@@ -1,6 +1,5 @@
->>>NAME<<<
-
->>>DESC<<<
+<%= name %>
+<%= description %>
 
 .. toctree::
     :maxdepth: 2
@@ -9,6 +8,5 @@
     overview.rst
     arch.rst
 
->>>CATS<<<
-
->>>RPCS<<<
+<%= categories %>
+<%= rpcs %>

--- a/src/server/services/procedures/phone-iot/docs/Display.rst
+++ b/src/server/services/procedures/phone-iot/docs/Display.rst
@@ -1,4 +1,4 @@
->>>NAME<<<
+<%= name %>
 
 This section covers all of the RPCs that relate to manipulation of the customizable interactive display on the mobile device.
 The device display is a large rectangular region called the `canvas`.
@@ -11,4 +11,4 @@ Many controls take optional parameters, which are specified as a list of pairs (
 For instance, most controls take one or more optional parameters to control the color of the display.
 You can obtain color codes from :func:`PhoneIoT.getColor`.
 
->>>RPCS<<<
+<%= rpcs %>

--- a/src/server/services/procedures/phone-iot/docs/Sensors.rst
+++ b/src/server/services/procedures/phone-iot/docs/Sensors.rst
@@ -1,7 +1,7 @@
->>>NAME<<<
+<%= name %>
 
 This section covers all of the RPCs that are specific to actively retrieving sensor data from the device.
 Each of these sensors has an equivelent passive form of access through :func:`PhoneIoT.listenToSensors`.
 The sensor names and message fields are provided for each sensor.
 
->>>RPCS<<<
+<%= rpcs %>

--- a/src/server/services/procedures/phone-iot/docs/Utility.rst
+++ b/src/server/services/procedures/phone-iot/docs/Utility.rst
@@ -1,5 +1,5 @@
->>>NAME<<<
+<%= name %>
 
 The RPCs listed in this section are not directly tied to any other part of PhoneIoT, but are helpers with using them.
 
->>>RPCS<<<
+<%= rpcs %>

--- a/src/server/services/services-worker.js
+++ b/src/server/services/services-worker.js
@@ -75,6 +75,7 @@ class ServicesWorker {
                 if (service.init) {
                     service.init(this._logger);
                 }
+                service._docs.apiKey = service.apiKey;
 
                 // Register the rpc actions, method signatures
                 if (service.serviceName) {
@@ -170,6 +171,7 @@ class ServicesWorker {
         serviceDoc.categories = service._docs.categories;
         serviceDoc.servicePath = service._docs.servicePath;
         serviceDoc.tags = service._docs.tags;
+        serviceDoc.apiKey = service._docs.apiKey;
         return serviceDoc;
     }
 


### PR DESCRIPTION
Closes #3106. I swapped over from regex replace for doc templating to ejs, and added some extra info to the metadata. This includes an `apiKeys` object, which is used in a normal ejs template to automatically generate the API key docs for all services.