### PR TITLE
PhoneIoT RPC cleanup

### DIFF
--- a/bin/prestart.js
+++ b/bin/prestart.js
@@ -86,10 +86,11 @@ function getRPCsMeta(service) {
             args: (rpc.args || []).map(arg => { return {
                 decl: getParamString(arg),
                 description: trimText(arg.rawDescription),
-                fields: !isObject(arg.type) || !(arg.type.params || []).length ? undefined : arg.type.params.map(field => { return {
-                    decl: getParamString(field),
-                    description: trimText(field.rawDescription),
-                }; }),
+                fields: !isObject(arg.type) || !(arg.type.params || []).length ? undefined : arg.type.params
+                    .filter(f => !f.tags.includes('deprecated')).map(field => { return {
+                        decl: getParamString(field),
+                        description: trimText(field.rawDescription),
+                    }; }),
             }; }),
             returns: rpc.returns ? { type: getTypeString(rpc.returns.type), description: trimText(rpc.returns.rawDescription) } : undefined,
         };

--- a/src/server/services/jsdoc-extractor.js
+++ b/src/server/services/jsdoc-extractor.js
@@ -29,6 +29,22 @@ function cleanMarkup(str) {
     return str;
 }
 
+function parseInlineTags(desc) {
+    if (!desc) return { tags: [], desc };
+    const tags = [];
+
+    while (true) {
+        const parsed = doctrine.parse(desc, {unwrap: true});
+        assert(!parsed.description.length || !parsed.tags.length, 'An inline tag may not have a description');
+        if (parsed.description.length) {
+            return { tags, description: parsed.description };
+        }
+        assert(parsed.tags.length === 1); // rest is desc on the tag
+        tags.push(parsed.tags[0].title);
+        desc = parsed.tags[0].description;
+    }
+}
+
 //simplifies a single metadata returned by doctrine to be used within netsblox
 function simplify(metadata) {
     let {description, tags} = metadata;
@@ -40,9 +56,8 @@ function simplify(metadata) {
     let simplifyParam = param => {
         let {name, type, description} = param;
         const rawDescription = description;
-        description = cleanMarkup(description);
 
-        let simpleParam = {name, description, rawDescription};
+        let simpleParam = {name, rawDescription};
 
         // if type is defined
         if (type) {
@@ -56,6 +71,13 @@ function simplify(metadata) {
             logger.warn(`rpc ${fnName}, parameter ${name} is missing the type attribute`);
         }
         return simpleParam;
+    };
+    let cleanDesc = arg => {
+        assert(arg.tags === undefined);
+        const parsedDesc = parseInlineTags(arg.rawDescription);
+        arg.rawDescription = parsedDesc.description;
+        arg.tags = parsedDesc.tags;
+        arg.description = cleanMarkup(arg.rawDescription);
     };
 
     let args = tags
@@ -73,8 +95,10 @@ function simplify(metadata) {
                     `Cannot add field ${fieldName} to ${objectName}. Argument is not an object.`
                 );
                 arg.name = fieldName;
+                cleanDesc(arg);
                 objectArg.type.params.push(arg);
             } else {
+                cleanDesc(arg);
                 args.push(arg);
             }
             return args;

--- a/src/server/services/jsdoc-extractor.js
+++ b/src/server/services/jsdoc-extractor.js
@@ -33,7 +33,7 @@ function parseInlineTags(desc) {
     if (!desc) return { tags: [], desc };
     const tags = [];
 
-    while (true) {
+    for (;;) {
         const parsed = doctrine.parse(desc, {unwrap: true});
         assert(!parsed.description.length || !parsed.tags.length, 'An inline tag may not have a description');
         if (parsed.description.length) {

--- a/src/server/services/procedures/phone-iot/common.js
+++ b/src/server/services/procedures/phone-iot/common.js
@@ -95,5 +95,8 @@ common.SENSOR_PACKERS = {
     'stepCount': vals => { return { count: vals[0] }; },
     'location': vals => { return { latitude: vals[0], longitude: vals[1], bearing: vals[2], altitude: vals[3] }; },
 };
+common.DEPRECATED_SENSORS = new Set([
+    'rotation', 'gameRotation',
+]);
 
 module.exports = common;

--- a/src/server/services/procedures/phone-iot/phone-iot.js
+++ b/src/server/services/procedures/phone-iot/phone-iot.js
@@ -667,9 +667,9 @@ if (PHONE_IOT_MODE === 'native' || PHONE_IOT_MODE === 'both') {
      * @param {SensorPeriod=} sensors.orientation ``orientation`` period
      * @param {SensorPeriod=} sensors.accelerometer ``accelerometer`` period
      * @param {SensorPeriod=} sensors.magneticField ``magneticField`` period
-     * @param {SensorPeriod=} sensors.rotation ``rotation`` period
+     * @param {SensorPeriod=} sensors.rotation @deprecated ``rotation`` period
      * @param {SensorPeriod=} sensors.linearAcceleration ``linearAcceleration`` period
-     * @param {SensorPeriod=} sensors.gameRotation ``gameRotation`` sensor period
+     * @param {SensorPeriod=} sensors.gameRotation @deprecated ``gameRotation`` sensor period
      * @param {SensorPeriod=} sensors.lightLevel ``lightLevel`` period
      * @param {SensorPeriod=} sensors.microphoneLevel ``microphoneLevel`` period
      * @param {SensorPeriod=} sensors.proximity ``proximity`` period
@@ -721,7 +721,7 @@ if (PHONE_IOT_MODE === 'native' || PHONE_IOT_MODE === 'both') {
      * @returns {Array} A list of sensor names
      */
     PhoneIoT.prototype.getSensors = function () {
-        return Object.keys(common.SENSOR_PACKERS);
+        return Object.keys(common.SENSOR_PACKERS).filter(s => !common.DEPRECATED_SENSORS.has(s));
     };
     /**
      * This is the first RPC you should *always* call when working with PhoneIoT.
@@ -785,7 +785,10 @@ if (PHONE_IOT_MODE === 'native' || PHONE_IOT_MODE === 'both') {
      * 
      * - azimuth (effectively the compass heading) ``[-180, 180]``
      * - pitch (vertical tilt) ``[-90, 90]``
-     * - roll ``[-90, 90]``
+     * - roll ``[-180, 180]``
+     * 
+     * If you are getting inconsistent values for the first (azimuth) angle,
+     * try moving and rotating your device around in a figure-8 to recalibrate it.
      * 
      * Sensor name: ``orientation``
      * 
@@ -803,6 +806,8 @@ if (PHONE_IOT_MODE === 'native' || PHONE_IOT_MODE === 'both') {
      * This is provided by the magnetic field sensor, so using this RPC on devices without a magnetometer will result in an error.
      * The output of this RPC assumes the device is face-up.
      * 
+     * If you are getting inconsistent values, try moving and rotating your device around in a figure-8 to recalibrate it.
+     * 
      * @category Sensors
      * @param {Device} device id of the device
      * @returns {Number} the compass heading (in degrees)
@@ -815,6 +820,8 @@ if (PHONE_IOT_MODE === 'native' || PHONE_IOT_MODE === 'both') {
      * This is provided by the magnetic field sensor, so using this RPC on devices without a magnetometer will result in an error.
      * The output of this RPC assumes the device is face-up.
      * 
+     * If you are getting inconsistent values, try moving and rotating your device around in a figure-8 to recalibrate it.
+     * 
      * @category Sensors
      * @param {Device} device id of the device
      * @returns {String} the current compass direction name
@@ -824,6 +831,8 @@ if (PHONE_IOT_MODE === 'native' || PHONE_IOT_MODE === 'both') {
     };
     /**
      * Equivalent to :func:`PhoneIoT.getCompassDirection`, except that it only returns ``N``, ``E``, ``S``, or ``W``.
+     * 
+     * If you are getting inconsistent values, try moving and rotating your device around in a figure-8 to recalibrate it.
      * 
      * @category Sensors
      * @param {Device} device id of the device
@@ -930,6 +939,7 @@ if (PHONE_IOT_MODE === 'native' || PHONE_IOT_MODE === 'both') {
      * 
      * Message fields: ``x``, ``y``, ``z``, ``w``
      * 
+     * @deprecated
      * @category Sensors
      * @param {Device} device id of the device
      * @returns {Array} 4D rotational vector
@@ -944,6 +954,7 @@ if (PHONE_IOT_MODE === 'native' || PHONE_IOT_MODE === 'both') {
      * 
      * Message fields: ``x``, ``y``, ``z``
      * 
+     * @deprecated
      * @category Sensors
      * @param {Device} device id of the device
      * @returns {Array} 3D rotational vector

--- a/test/unit/server/services/jsdoc-extractor.spec.js
+++ b/test/unit/server/services/jsdoc-extractor.spec.js
@@ -69,6 +69,7 @@ describe(utils.suiteName(__filename), function() {
                 },
                 description,
                 rawDescription: description,
+                tags: [],
             });
             let simpleMetadata = jp._simplify(metadata.parsed);
 


### PR DESCRIPTION
In PhoneIoT there were two RPCs I was supporting that I don't see any use for anymore (and might be confusing). One was `getRotation`, which returns a 4D vector and is therefore overcomplicated for students. The other was `getGameRotation`, which, while not identical to `getOrientation`, is basically the same thing (just a different reference frame). Orientation is better due to being absolute.
So I marked these RPCs as deprecated.

More interestingly, I noticed there wasn't a way to mark duck typing fields as deprecated, so I added that. This was needed to make the `rotation` and `gameRotation` fields on `listenToSensors` not show up in the docs. Now, any `@param {type} <name> <desc>` will have its description parsed for leading tags.