### PR TITLE
Add numeric display feature for simulated robots

### DIFF
--- a/src/server/services/procedures/roboscape/robot.js
+++ b/src/server/services/procedures/roboscape/robot.js
@@ -524,7 +524,7 @@ Robot.prototype.onCommand = function(command) {
         {
             regex: /^show number (\d+)(?:[, ](\d+))?$/,
             handler: () => {
-                this.setNumericDisplay(+RegExp.$1, (+RegExp.$2 == 0)? undefined : +RegExp.$2);
+                this.setNumericDisplay(+RegExp.$1, (RegExp.$2 == '')? undefined : +RegExp.$2);
             }
         },
         {


### PR DESCRIPTION
Close #3124 

This PR quickly adds the ability to send a uint8 to a robot for display and modifies the HW key generation code to send these to robots (although physical robots can't respond to it yet).

It also includes a command to access it, which students could use e.g. to display output on the robot instead of only on the stage:
![myRole script pic(4)](https://user-images.githubusercontent.com/7331488/119419074-0d216580-bcbf-11eb-8b34-3f9e342d07a3.png)
