### PR TITLE
Remove autograder warning docs

### DIFF
--- a/src/server/services/procedures/autograders/autograders.js
+++ b/src/server/services/procedures/autograders/autograders.js
@@ -2,7 +2,7 @@
  * The Autograders service enables users to create custom autograders for
  * use within NetsBlox.
  *
- * For more information, check out https://github.com/NetsBlox/NetsBlox/wiki/Autograders-Overview
+ * For more information, check out https://editor.netsblox.org/docs/services/Autograders/index.html
  *
  * @service
  */

--- a/src/server/services/procedures/autograders/docs/overview.rst
+++ b/src/server/services/procedures/autograders/docs/overview.rst
@@ -1,9 +1,6 @@
 Overview
 ========
 
-*Note: Autograders are currently experimental! Feel free to use them at your own risk :)
-As the following depends on unstable features, they are only available on https://dev.netsblox.org for now.*
-
 The ``Autograders`` service provides capabilities for creating custom autograders in NetsBlox.
 Autograders are created similarly to community services.
 That is, they expect a configuration dictionary (list of lists) that contains information like the course/grader name and assignments.


### PR DESCRIPTION
Down the road, it would probably be nice to have the documentation detect the server URL rather than hardcoding editor.netsblox.org but this works for now...