### PR TITLE
PhoneIoT extended sensor update fields

### DIFF
--- a/src/server/services/procedures/phone-iot/common.js
+++ b/src/server/services/procedures/phone-iot/common.js
@@ -4,6 +4,33 @@ const types = require('../../input-types');
 
 const common = {};
 
+common.DIRECTIONS_3D = [
+    [[0, 0, 1], 'up'],
+    [[0, 0, -1], 'down'],
+    [[0, 1, 0], 'vertical'],
+    [[0, -1, 0], 'upside down'],
+    [[1, 0, 0], 'left'],
+    [[-1, 0, 0], 'right'],
+];
+common.COMPASS_DIRECTIONS_4 = [
+    [0, 'N'],
+    [90, 'E'],
+    [-90, 'W'],
+    [180, 'S'],
+    [-180, 'S'],
+];
+common.COMPASS_DIRECTIONS_8 = [
+    [0, 'N'],
+    [45, 'NE'],
+    [-45, 'NW'],
+    [90, 'E'],
+    [-90, 'W'],
+    [135, 'SE'],
+    [-135, 'SW'],
+    [180, 'S'],
+    [-180, 'S'],
+];
+
 common.dotProduct = function(a, b) {
     let total = 0;
     for (var i = 0; i < a.length; ++i) {
@@ -80,11 +107,21 @@ common.prepImageToSend = async function(raw) {
 
 function packXYZ(vals) { return { x: vals[0], y: vals[1], z: vals[2] }; };
 function packXYZW(vals) { return { x: vals[0], y: vals[1], z: vals[2], w: vals[3] }; };
+function packAcceleration(vals) {
+    const facingDir = common.closestVector(vals, common.DIRECTIONS_3D);
+    return { x: vals[0], y: vals[1], z: vals[2], facingDir };
+}
+function packOrientation(vals) {
+    const heading = vals[0];
+    const dir = common.closestScalar(heading, common.COMPASS_DIRECTIONS_8);
+    const cardinalDir = common.closestScalar(heading, common.COMPASS_DIRECTIONS_4);
+    return { x: vals[0], y: vals[1], z: vals[2], heading, dir, cardinalDir };
+}
 common.SENSOR_PACKERS = {
     'gravity': packXYZ,
     'gyroscope': packXYZ,
-    'orientation': packXYZ,
-    'accelerometer': packXYZ,
+    'orientation': packOrientation,
+    'accelerometer': packAcceleration,
     'magneticField': packXYZ,
     'rotation': packXYZW,
     'linearAcceleration': packXYZ,

--- a/src/server/services/procedures/phone-iot/device.js
+++ b/src/server/services/procedures/phone-iot/device.js
@@ -55,33 +55,6 @@ const common = require('./common');
 const FORGET_TIME = 120; // forgetting a device in seconds
 const RESPONSE_TIMEOUT = 2000; // ms (well over worst case)
 
-const DIRECTIONS_3D = [
-    [[0, 0, 1], 'up'],
-    [[0, 0, -1], 'down'],
-    [[0, 1, 0], 'vertical'],
-    [[0, -1, 0], 'upside down'],
-    [[1, 0, 0], 'left'],
-    [[-1, 0, 0], 'right'],  
-];
-const COMPASS_DIRECTIONS_4 = [
-    [0, 'N'],
-    [90, 'E'],
-    [-90, 'W'],
-    [180, 'S'],
-    [-180, 'S'],
-];
-const COMPASS_DIRECTIONS_8 = [
-    [0, 'N'],
-    [45, 'NE'],
-    [-45, 'NW'],
-    [90, 'E'],
-    [-90, 'W'],
-    [135, 'SE'],
-    [-135, 'SW'],
-    [180, 'S'],
-    [-180, 'S'],
-];
-
 const Device = function (mac_addr, ip4_addr, ip4_port, aServer) {
     this.id = mac_addr;
     this.mac_addr = mac_addr;
@@ -713,10 +686,10 @@ Device.prototype.getCompassHeading = async function (device, args, clientId) {
     return (await this.getOrientation(device, args, clientId))[0];
 };
 Device.prototype.getCompassDirection = async function (device, args, clientId) {
-    return common.closestScalar(await this.getCompassHeading(device, args, clientId), COMPASS_DIRECTIONS_8);
+    return common.closestScalar(await this.getCompassHeading(device, args, clientId), common.COMPASS_DIRECTIONS_8);
 };
 Device.prototype.getCompassCardinalDirection = async function (device, args, clientId) {
-    return common.closestScalar(await this.getCompassHeading(device, args, clientId), COMPASS_DIRECTIONS_4);
+    return common.closestScalar(await this.getCompassHeading(device, args, clientId), common.COMPASS_DIRECTIONS_4);
 };
 
 Device.prototype.getAccelerometer = async function (device, args, clientId) {
@@ -730,7 +703,7 @@ Device.prototype.getAccelerometer = async function (device, args, clientId) {
     return throwIfErr(await response).vals;
 };
 Device.prototype.getFacingDirection = async function (device, args, clientId) {
-    return common.closestVector(await this.getAccelerometer(device, args, clientId), DIRECTIONS_3D);
+    return common.closestVector(await this.getAccelerometer(device, args, clientId), common.DIRECTIONS_3D);
 };
 
 Device.prototype.getGravity = async function (device, args, clientId) {

--- a/src/server/services/procedures/phone-iot/phone-iot.js
+++ b/src/server/services/procedures/phone-iot/phone-iot.js
@@ -792,7 +792,7 @@ if (PHONE_IOT_MODE === 'native' || PHONE_IOT_MODE === 'both') {
      * 
      * Sensor name: ``orientation``
      * 
-     * Message fields: ``x``, ``y``, ``z``
+     * Message fields: ``x``, ``y``, ``z``, ``heading``, ``dir``, ``cardinalDir``
      * 
      * @category Sensors
      * @param {Device} device id of the device
@@ -808,6 +808,10 @@ if (PHONE_IOT_MODE === 'native' || PHONE_IOT_MODE === 'both') {
      * 
      * If you are getting inconsistent values, try moving and rotating your device around in a figure-8 to recalibrate it.
      * 
+     * Sensor name: ``orientation``
+     * 
+     * Message fields: ``x``, ``y``, ``z``, ``heading``, ``dir``, ``cardinalDir``
+     * 
      * @category Sensors
      * @param {Device} device id of the device
      * @returns {Number} the compass heading (in degrees)
@@ -822,6 +826,10 @@ if (PHONE_IOT_MODE === 'native' || PHONE_IOT_MODE === 'both') {
      * 
      * If you are getting inconsistent values, try moving and rotating your device around in a figure-8 to recalibrate it.
      * 
+     * Sensor name: ``orientation``
+     * 
+     * Message fields: ``x``, ``y``, ``z``, ``heading``, ``dir``, ``cardinalDir``
+     * 
      * @category Sensors
      * @param {Device} device id of the device
      * @returns {String} the current compass direction name
@@ -833,6 +841,10 @@ if (PHONE_IOT_MODE === 'native' || PHONE_IOT_MODE === 'both') {
      * Equivalent to :func:`PhoneIoT.getCompassDirection`, except that it only returns ``N``, ``E``, ``S``, or ``W``.
      * 
      * If you are getting inconsistent values, try moving and rotating your device around in a figure-8 to recalibrate it.
+     * 
+     * Sensor name: ``orientation``
+     * 
+     * Message fields: ``x``, ``y``, ``z``, ``heading``, ``dir``, ``cardinalDir``
      * 
      * @category Sensors
      * @param {Device} device id of the device
@@ -849,7 +861,7 @@ if (PHONE_IOT_MODE === 'native' || PHONE_IOT_MODE === 'both') {
      * 
      * Sensor name: ``accelerometer``
      * 
-     * Message fields: ``x``, ``y``, ``z``
+     * Message fields: ``x``, ``y``, ``z``, ``facingDir``
      * 
      * @category Sensors
      * @param {Device} device id of the device
@@ -869,6 +881,10 @@ if (PHONE_IOT_MODE === 'native' || PHONE_IOT_MODE === 'both') {
      * - ``upside down`` - the device is vertical, but upside down
      * - ``left`` - the device is horizontal, lying on its left side (when facing the screen)
      * - ``right`` - the device is horizontal, lying on its right side (when facing the screen)
+     * 
+     * Sensor name: ``accelerometer``
+     * 
+     * Message fields: ``x``, ``y``, ``z``, ``facingDir``
      * 
      * @category Sensors
      * @param {Device} device id of the device


### PR DESCRIPTION
PhoneIoT had some special sensor getters like `getCompassDirection` that didn't have data streaming equivalents (for `listenToSensors`). This PR just adds extra fields to the accelerometer and orientation sensor messages with those extra values.