### PR TITLE
Repeat number messages for RoboScape key

### DIFF
--- a/src/server/services/procedures/roboscape/robot.js
+++ b/src/server/services/procedures/roboscape/robot.js
@@ -654,7 +654,9 @@ Robot.prototype.playNumbers = function (states, delay = 4000) {
         index = 0,
         step = function () {            
             if (index < states.length) {
-                myself.setNumericDisplay(states[index], delay - 500);
+                for (let repeat = 0; repeat < 3; repeat++) {
+                    myself.setNumericDisplay(states[index], delay - 500);
+                }
                 index += 1;
                 setTimeout(step, delay);
             }


### PR DESCRIPTION
@brollb This change is needed for tomorrow's camp. Would you be able to get a new version onto editor with this included?

The number key messages previously weren't being repeated like the LED blinks for the keys are. We were having issues with them not showing up reliably. 

Eventually we'll need a better fix for this, but there isn't time before the camp tomorrow. Repeating them like the LED messages already do seems to solve the problem for now.