### PR TITLE
use services server for doc filtering

### DIFF
--- a/bin/build-docs.js
+++ b/bin/build-docs.js
@@ -39,8 +39,22 @@ function getParamString(param) {
 }
 
 async function getLoadedServices() {
-    const res = await axios.get(process.env.SERVICES_URL || 'http://127.0.0.1:8080/services');
-    return res.data.map(s => s.name);
+    try {
+        const res = await axios.get(process.env.SERVICES_URL || 'http://127.0.0.1:8080/services');
+        return res.data.map(s => s.name);
+    } catch (err) {
+        if (err.errno === 'ECONNREFUSED') {
+            const msg = process.env.SERVICES_URL ? `Unable to connect to ${process.env.SERVICES_URL}. Is this the correct address?` :
+                'Unable to connect to services server. Please set the SERVICES_URL environment variable and retry.';
+            throw new Error(msg);
+        } else if (process.env.SERVICES_URL) {
+            const msg = `${process.env.SERVICES_URL} is not a valid address for NetsBlox services. ` +
+                'It should be either the services server directly or the main server URL with "/services" appended.\n\n' +
+                'For example, https://editor.netsblox.org/services.';
+            throw new Error(msg);
+        }
+        throw err;
+    }
 }
 
 const SERVICE_FILTERS = {

--- a/bin/build-docs.js
+++ b/bin/build-docs.js
@@ -10,6 +10,7 @@ const {exec} = require('child_process');
 const utils = require('./../src/server/api/cli/utils');
 const Logger = require('../src/server/logger');
 const ServicesWorker = require('./../src/server/services/services-worker');
+const axios = require('axios');
 
 process.chdir(srcPath);
 utils.runWithStorage(build).catch(err => console.error(err));
@@ -37,14 +38,19 @@ function getParamString(param) {
     return param.optional ? `${str}?` : str;
 }
 
+async function getLoadedServices() {
+    const res = await axios.get(process.env.SERVICES_URL);
+    return res.data.map(s => s.name);
+}
+
 const SERVICE_FILTERS = {
     all: () => true,
-    nodeprecated: service => !service.tags.includes('deprecated'),
-    fsonly: service => service.servicePath,
+    nodeprecated: (name, meta) => !meta.tags.includes('deprecated'),
+    fsonly: (name, meta) => meta.servicePath,
 };
-function getServiceFilter(filterString = 'fsonly,nodeprecated') {
+function getServiceFilter(loadedServices, filterString = 'fsonly,nodeprecated') {
     const filters = filterString.split(',').map(s => s.trim()).filter(s => s.length).map(s => SERVICE_FILTERS[s]);
-    return s => filters.every(f => f(s));
+    return (name, meta) => loadedServices.includes(name) && filters.every(f => f(name, meta));
 }
 
 const SERVICE_DIR_REGEX = /(.*)\/.*\.js/;
@@ -107,11 +113,8 @@ function getMeta(services, serviceFilter) {
     const apiKeys = {};
 
     for (const serviceName in services.metadata) {
-        if (!services.isServiceLoaded(serviceName)) {
-            continue;
-        }
         const service = services.metadata[serviceName];
-        if (!serviceFilter(service)) continue;
+        if (!serviceFilter(serviceName, service)) continue;
 
         updateCategories(categories, serviceName, service);
         servicesMeta[serviceName] = {
@@ -217,7 +220,8 @@ async function cleanRoot() {
 async function compileDocs(services) {
     const rootDocs = await cleanRoot();
 
-    const serviceFilter = getServiceFilter(process.env.DOCS_SERVICE_FILTER);
+    const loadedServices = await getLoadedServices();
+    const serviceFilter = getServiceFilter(loadedServices, process.env.DOCS_SERVICE_FILTER);
     const meta = getMeta(services, serviceFilter);
     const servicesString = '\n\n.. toctree::\n    :maxdepth: 2\n    :titlesonly:\n    :caption: Services\n\n    '
         + (Object.keys(meta.categories).concat(meta.categories.index.items)).filter(s => s !== 'index').sort().map(item => {

--- a/bin/build-docs.js
+++ b/bin/build-docs.js
@@ -39,7 +39,7 @@ function getParamString(param) {
 }
 
 async function getLoadedServices() {
-    const res = await axios.get(process.env.SERVICES_URL);
+    const res = await axios.get(process.env.SERVICES_URL || 'http://127.0.0.1:8080/services');
     return res.data.map(s => s.name);
 }
 

--- a/bin/build-docs.js
+++ b/bin/build-docs.js
@@ -63,8 +63,10 @@ const SERVICE_FILTERS = {
     fsonly: (name, meta) => meta.servicePath,
 };
 function getServiceFilter(loadedServices, filterString = 'fsonly,nodeprecated') {
+    const isServiceLoaded = name => loadedServices.includes(name);
     const filters = filterString.split(',').map(s => s.trim()).filter(s => s.length).map(s => SERVICE_FILTERS[s]);
-    return (name, meta) => loadedServices.includes(name) && filters.every(f => f(name, meta));
+    filters.unshift(isServiceLoaded);
+    return (name, meta) => filters.every(f => f(name, meta));
 }
 
 const SERVICE_DIR_REGEX = /(.*)\/.*\.js/;

--- a/bin/netsblox-start.js
+++ b/bin/netsblox-start.js
@@ -66,13 +66,13 @@ if (program.services) {
         useServiceProxy: isSetToTrue(process.env.PROXY_RPCS) || startAll
     };
 
-    const buildDocsBin = path.join(__dirname, 'build-docs.js');
-    const buildDocs = spawn('node', [buildDocsBin], {env: process.env});
-    buildDocs.stdout.pipe(process.stdout);
-    buildDocs.stderr.pipe(process.stderr);
     const server = new Server(opts);
-
-    server.start();
+    server.start().then(() => {
+        const buildDocsBin = path.join(__dirname, 'build-docs.js');
+        const buildDocs = spawn('node', [buildDocsBin], {env: process.env});
+        buildDocs.stdout.pipe(process.stdout);
+        buildDocs.stderr.pipe(process.stderr);
+    });
 }
 
 function isSetToTrue(envValue) {


### PR DESCRIPTION
Closes #3143. Switched over to using the services server for doc filtering. Not sure how to test it like the deployment would be, but it works on local and it targets the `SERVICES_URL` env var, so that's probably ok.