### PR TITLE
PhoneIoT connection reset

### DIFF
--- a/src/server/services/procedures/phone-iot/device.js
+++ b/src/server/services/procedures/phone-iot/device.js
@@ -88,6 +88,8 @@ const Device = function (mac_addr, ip4_addr, ip4_port, aServer) {
     this.sensorPacketTimestamp = -1; // timestamp of last sensor packet
 
     this.controlCount = 0; // counter used to generate unique custom control ids
+
+    this.requestDisconnect = false; // when set to true, _heartbeat will delete us (in phone-iot.js)
 };
 
 Device.prototype.getPassword = function (clientId) {
@@ -1018,10 +1020,21 @@ Device.prototype.onMessage = function (message) {
             this.setEncryptionKey([]);
             this.resetRates();
         }
-        if (message.length > 11) {
-            const rsp = Buffer.alloc(1);
-            rsp.write('I', 0, 1);
-            this.sendToDevice(rsp);
+        if (message.length === 12) {
+            if (message[11] === 0) { // send conn ack
+                const rsp = Buffer.alloc(2);
+                rsp.write('I', 0, 1);
+                rsp[1] = 1;
+                this.sendToDevice(rsp);
+            }
+            else if (message[11] === 86) { // disconnect (and send disconn ack)
+                this.requestDisconnect = true;
+
+                const rsp = Buffer.alloc(2);
+                rsp.write('I', 0, 1);
+                rsp[1] = 87;
+                this.sendToDevice(rsp);
+            }
         }
     }
     else if (command === 'Q') {

--- a/src/server/services/procedures/phone-iot/phone-iot.js
+++ b/src/server/services/procedures/phone-iot/phone-iot.js
@@ -792,7 +792,7 @@ if (PHONE_IOT_MODE === 'native' || PHONE_IOT_MODE === 'both') {
      * 
      * Sensor name: ``orientation``
      * 
-     * Message fields: ``x``, ``y``, ``z``, ``heading``, ``dir``, ``cardinalDir``
+     * Message fields: ``x``, ``y``, ``z``, ``heading``, ``dir``, ``cardinalDir``, ``device``
      * 
      * @category Sensors
      * @param {Device} device id of the device
@@ -810,7 +810,7 @@ if (PHONE_IOT_MODE === 'native' || PHONE_IOT_MODE === 'both') {
      * 
      * Sensor name: ``orientation``
      * 
-     * Message fields: ``x``, ``y``, ``z``, ``heading``, ``dir``, ``cardinalDir``
+     * Message fields: ``x``, ``y``, ``z``, ``heading``, ``dir``, ``cardinalDir``, ``device``
      * 
      * @category Sensors
      * @param {Device} device id of the device
@@ -828,7 +828,7 @@ if (PHONE_IOT_MODE === 'native' || PHONE_IOT_MODE === 'both') {
      * 
      * Sensor name: ``orientation``
      * 
-     * Message fields: ``x``, ``y``, ``z``, ``heading``, ``dir``, ``cardinalDir``
+     * Message fields: ``x``, ``y``, ``z``, ``heading``, ``dir``, ``cardinalDir``, ``device``
      * 
      * @category Sensors
      * @param {Device} device id of the device
@@ -844,7 +844,7 @@ if (PHONE_IOT_MODE === 'native' || PHONE_IOT_MODE === 'both') {
      * 
      * Sensor name: ``orientation``
      * 
-     * Message fields: ``x``, ``y``, ``z``, ``heading``, ``dir``, ``cardinalDir``
+     * Message fields: ``x``, ``y``, ``z``, ``heading``, ``dir``, ``cardinalDir``, ``device``
      * 
      * @category Sensors
      * @param {Device} device id of the device
@@ -861,7 +861,7 @@ if (PHONE_IOT_MODE === 'native' || PHONE_IOT_MODE === 'both') {
      * 
      * Sensor name: ``accelerometer``
      * 
-     * Message fields: ``x``, ``y``, ``z``, ``facingDir``
+     * Message fields: ``x``, ``y``, ``z``, ``facingDir``, ``device``
      * 
      * @category Sensors
      * @param {Device} device id of the device
@@ -884,7 +884,7 @@ if (PHONE_IOT_MODE === 'native' || PHONE_IOT_MODE === 'both') {
      * 
      * Sensor name: ``accelerometer``
      * 
-     * Message fields: ``x``, ``y``, ``z``, ``facingDir``
+     * Message fields: ``x``, ``y``, ``z``, ``facingDir``, ``device``
      * 
      * @category Sensors
      * @param {Device} device id of the device
@@ -903,7 +903,7 @@ if (PHONE_IOT_MODE === 'native' || PHONE_IOT_MODE === 'both') {
      * 
      * Sensor name: ``gravity``
      * 
-     * Message fields: ``x``, ``y``, ``z``
+     * Message fields: ``x``, ``y``, ``z``, ``device``
      * 
      * @category Sensors
      * @param {Device} device id of the device
@@ -922,7 +922,7 @@ if (PHONE_IOT_MODE === 'native' || PHONE_IOT_MODE === 'both') {
      * 
      * Sensor name: ``linearAcceleration``
      * 
-     * Message fields: ``x``, ``y``, ``z``
+     * Message fields: ``x``, ``y``, ``z``, ``device``
      * 
      * @category Sensors
      * @param {Device} device id of the device
@@ -937,7 +937,7 @@ if (PHONE_IOT_MODE === 'native' || PHONE_IOT_MODE === 'both') {
      * 
      * Sensor name: ``gyroscope``
      * 
-     * Message fields: ``x``, ``y``, ``z``
+     * Message fields: ``x``, ``y``, ``z``, ``device``
      * 
      * @category Sensors
      * @param {Device} device id of the device
@@ -953,7 +953,7 @@ if (PHONE_IOT_MODE === 'native' || PHONE_IOT_MODE === 'both') {
      * 
      * Sensor name: ``rotation``
      * 
-     * Message fields: ``x``, ``y``, ``z``, ``w``
+     * Message fields: ``x``, ``y``, ``z``, ``w``, ``device``
      * 
      * @deprecated
      * @category Sensors
@@ -968,7 +968,7 @@ if (PHONE_IOT_MODE === 'native' || PHONE_IOT_MODE === 'both') {
      * 
      * Sensor name: ``gameRotation``
      * 
-     * Message fields: ``x``, ``y``, ``z``
+     * Message fields: ``x``, ``y``, ``z``, ``device``
      * 
      * @deprecated
      * @category Sensors
@@ -987,7 +987,7 @@ if (PHONE_IOT_MODE === 'native' || PHONE_IOT_MODE === 'both') {
      * 
      * Sensor name: ``magneticField``
      * 
-     * Message fields: ``x``, ``y``, ``z``
+     * Message fields: ``x``, ``y``, ``z``, ``device``
      * 
      * @category Sensors
      * @param {Device} device id of the device
@@ -1003,7 +1003,7 @@ if (PHONE_IOT_MODE === 'native' || PHONE_IOT_MODE === 'both') {
      * 
      * Sensor name: ``microphoneLevel``
      * 
-     * Message fields: ``volume``
+     * Message fields: ``volume``, ``device``
      * 
      * @category Sensors
      * @param {Device} device id of the device
@@ -1019,7 +1019,7 @@ if (PHONE_IOT_MODE === 'native' || PHONE_IOT_MODE === 'both') {
      * 
      * Sensor name: ``location``
      * 
-     * Message fields: ``latitude``, ``longitude``, ``bearing``, ``altitude``
+     * Message fields: ``latitude``, ``longitude``, ``bearing``, ``altitude``, ``device``
      * 
      * @category Sensors
      * @param {Device} device id of the device
@@ -1036,7 +1036,8 @@ if (PHONE_IOT_MODE === 'native' || PHONE_IOT_MODE === 'both') {
      * 
      * Sensor name: ``location``
      * 
-     * Message fields: ``latitude``, ``longitude``, ``bearing``, ``altitude``
+     * Message fields: ``latitude``, ``longitude``, ``bearing``, ``altitude``, ``device``
+     * 
      * @category Sensors
      * @param {Device} device id of the device
      * @returns {Number} current bearing (in degrees)
@@ -1050,7 +1051,7 @@ if (PHONE_IOT_MODE === 'native' || PHONE_IOT_MODE === 'both') {
      * 
      * Sensor name: ``location``
      * 
-     * Message fields: ``latitude``, ``longitude``, ``bearing``, ``altitude``
+     * Message fields: ``latitude``, ``longitude``, ``bearing``, ``altitude``, ``device``
      * 
      * @category Sensors
      * @param {Device} device id of the device
@@ -1067,7 +1068,7 @@ if (PHONE_IOT_MODE === 'native' || PHONE_IOT_MODE === 'both') {
      * 
      * Sensor name: ``proximity``
      * 
-     * Message fields: ``distance``
+     * Message fields: ``distance``, ``device``
      * 
      * @category Sensors
      * @param {Device} device id of the device
@@ -1082,7 +1083,7 @@ if (PHONE_IOT_MODE === 'native' || PHONE_IOT_MODE === 'both') {
      * 
      * Sensor name: ``stepCount``
      * 
-     * Message fields: ``count``
+     * Message fields: ``count``, ``device``
      * 
      * @category Sensors
      * @param {Device} device id of the device
@@ -1097,7 +1098,7 @@ if (PHONE_IOT_MODE === 'native' || PHONE_IOT_MODE === 'both') {
      * 
      * Sensor name: ``lightLevel``
      * 
-     * Message fields: ``value``
+     * Message fields: ``value``, ``device``
      * 
      * @category Sensors
      * @param {Device} device id of the device

--- a/src/server/services/procedures/phone-iot/phone-iot.js
+++ b/src/server/services/procedures/phone-iot/phone-iot.js
@@ -122,12 +122,12 @@ PhoneIoT.prototype._getOrCreateDevice = function (mac_addr, ip4_addr, ip4_port) 
 PhoneIoT.prototype._heartbeat = function () {
     for (const mac_addr in PhoneIoT.prototype._devices) {
         const device = PhoneIoT.prototype._devices[mac_addr];
-        if (!device.heartbeat()) {
+        if (device.requestDisconnect || !device.heartbeat()) {
             logger.log('forgetting ' + mac_addr);
             delete PhoneIoT.prototype._devices[mac_addr];
         }
     }
-    setTimeout(PhoneIoT.prototype._heartbeat, 1000);
+    setTimeout(PhoneIoT.prototype._heartbeat, 1000); // must be every second to preserve timing logic
 };
 
 /**


### PR DESCRIPTION
Added a feature to let PhoneIoT devices request to be forgotten (and then re-registered) in case there's ever an issue with the sending socket on the server side (a non-reproducible bug I ran into twice). Also, if we ever add encryption (already in there, but not used), this'll let the user reset the password manually.