### PR TITLE
thingspeak service fix

### DIFF
--- a/src/server/services/procedures/thing-speak/thing-speak.js
+++ b/src/server/services/procedures/thing-speak/thing-speak.js
@@ -47,7 +47,7 @@ function detailParser(item) {
         delete dat.longitude;
     }
     return dat;
-};
+}
 
 thingspeakIoT._paginatedSearch = async function(path, query, limit=15) {
     if (limit < 1) return [];

--- a/test/unit/server/services/procedures/thingspeak.spec.js
+++ b/test/unit/server/services/procedures/thingspeak.spec.js
@@ -4,7 +4,7 @@ describe(utils.suiteName(__filename), function() {
     utils.verifyRPCInterfaces('Thingspeak', [
         ['searchByTag', ['tag', 'limit']],
         ['searchByLocation', ['latitude', 'longitude', 'distance', 'limit']],
-        ['searchByTagAndLocation', ['tag','latitude', 'longitude', 'distance']],
+        ['searchByTagAndLocation', ['tag','latitude', 'longitude', 'distance', 'limit']],
         ['channelFeed', ['id', 'numResult']],
         ['privateChannelFeed', ['id', 'numResult', 'apiKey']],
         ['channelDetails', ['id']]


### PR DESCRIPTION
The search functions for thingspeak seem to be the only parts that weren't working (details and feeds look good, though I didn't test private feeds). This PR fixes the search methods, which seemed to be returning an arbitrary number of results, some of which were empty. I rewrote the relevant functions in more modern async style to be more readable. I added a limit param for search by tag and location. This also happens to fix #1544.