### PR TITLE
Don't follow redirects when proxying requests to the services. Fix #3193

### DIFF
--- a/src/server/server.js
+++ b/src/server/server.js
@@ -34,7 +34,7 @@ const middleware = require('./routes/middleware');
 const Client = require('./client');
 const Messages = require('./services/messages');
 const assert = require('assert');
-const request = require('request');
+const axios = require('axios');
 const CustomServicesHosts = require('./api/core/services-hosts');
 const RestAPI = require('./api/rest');
 
@@ -79,18 +79,30 @@ Server.prototype.configureRoutes = async function(servicesURL) {
     if (servicesURL) {
         this.app.use('/services', (req, res) => {
             const url = servicesURL + req.originalUrl.replace('/services', '');
-            const proxyReq = request({
+            const opts = {
                 method: req.method,
-                uri: url,
-                body: req.body,
+                url: url,
+                responseType: 'stream',
                 headers: req.headers,
-                json: true,
-            });
-            proxyReq.on('error', err => {
-                this._logger.warn(`Error occurred on call to ${url}: ${err}`);
-                res.sendStatus(500);
-            });
-            return proxyReq.pipe(res);
+                data: req.body,
+                maxRedirects: 0,
+            };
+            return axios(opts)
+                .then(proxyResponse => proxyResponse.data.pipe(res))
+                .catch(err => {
+                    if (err.response) {
+                        const {status, data, headers} = err.response;
+                        Object.entries(headers).forEach(header => {
+                            const [field, value] = header;
+                            res.set(field, value);
+                        });
+                        res.status(status);
+                        return data.pipe(res);
+                    } else {
+                        this._logger.warn(`Error occurred on call to ${url}: ${err}`);
+                        return res.sendStatus(500);
+                    }
+                });
         });
     }
 


### PR DESCRIPTION
Don't follow redirects when proxying requests to the services. This also removes one more usage of the deprecated `requests` module.