### PR TITLE
3262 JSON error from FBICrimeData

### DIFF
--- a/src/server/services/procedures/fbi-crime-data/types.js
+++ b/src/server/services/procedures/fbi-crime-data/types.js
@@ -248,7 +248,7 @@ const US_TERRITORIES = {
 };
 
 const US_REGIONS = {
-    'Territories': 'Territories',
+    'Territories': 'U.S. Territories',
     'Northeast': 'Northeast',
     'Midwest': 'Midwest',
     'South': 'South',


### PR DESCRIPTION
Closes #3262. Apparently their value for `Territories` should actually be `U.S. Territories`, so I just changed the mapped value.