### PR TITLE
Handle malformed JSON in IoTScape better

### DIFF
--- a/src/server/services/procedures/iotscape/iotscape-services.js
+++ b/src/server/services/procedures/iotscape/iotscape-services.js
@@ -237,7 +237,14 @@ IoTScapeServices.start = function(socket){
 
     // Handle incoming responses
     IoTScapeServices.socket.on('message', function (message) {
-        const parsed = JSON.parse(message);
+        let parsed;
+
+        try {
+            parsed = JSON.parse(message);
+        } catch(err){
+            logger.log('Error parsing IoTScape message: ' + err);
+            return;
+        }
 
         // Ignore other messages
         if(!parsed.request){

--- a/src/server/services/procedures/iotscape/iotscape-services.js
+++ b/src/server/services/procedures/iotscape/iotscape-services.js
@@ -259,10 +259,14 @@ IoTScapeServices.start = function(socket){
                 const methodInfo = IoTScapeServices.getFunctionInfo(IoTScapeServices._awaitingRequests[requestID].service, IoTScapeServices._awaitingRequests[requestID].function);
                 const responseType = methodInfo.returns.type;
 
-                if(responseType.length > 1) {
-                    IoTScapeServices._awaitingRequests[requestID].resolve(parsed.response);
-                } else {
-                    IoTScapeServices._awaitingRequests[requestID].resolve(...parsed.response);
+                try {
+                    if(responseType.length > 1) {
+                        IoTScapeServices._awaitingRequests[requestID].resolve(parsed.response);
+                    } else {
+                        IoTScapeServices._awaitingRequests[requestID].resolve(...parsed.response);
+                    }
+                } catch (error) {
+                    logger.log('IoTScape response invalid: ' + error);
                 }
 
                 delete IoTScapeServices._awaitingRequests[requestID];

--- a/src/server/services/procedures/iotscape/iotscape.js
+++ b/src/server/services/procedures/iotscape/iotscape.js
@@ -103,7 +103,14 @@ IoTScape.send = function (service, id, command){
  * @param {RemoteInfo} remote Remote host information
  */
 IoTScape._createService = async function(definition, remote) {    
-    let parsed = JSON.parse(definition);
+    let parsed;
+
+    try {
+        parsed = JSON.parse(definition);
+    } catch(err){
+        logger.log('Error parsing IoTScape service: ' + err);
+        return;
+    }
 
     // Ignore request messages sent to this method
     if(parsed.request){


### PR DESCRIPTION
This moves the JSON parsing into a try block so the error cases can be handled more gracefully.