### PR TITLE
update geolocation

### DIFF
--- a/src/server/services/procedures/geolocation/geolocation.js
+++ b/src/server/services/procedures/geolocation/geolocation.js
@@ -9,85 +9,60 @@ const {GoogleMapsKey} = require('../utils/api-key');
 const utils = require('../utils');
 const GeoLocationRPC = {};
 utils.setRequiredApiKey(GeoLocationRPC, GoogleMapsKey);
-const logger = require('../utils/logger')('geolocation');
 
+const logger = require('../utils/logger')('geolocation');
 const CacheManager = require('cache-manager');
 const NodeGeocoder = require('node-geocoder');
-const rp = require('request-promise');
 const jsonQuery = require('json-query');
+const rp = require('request-promise');
 
-// init
-var cache = CacheManager.caching({store: 'memory', max: 1000, ttl: 36000}),
-    GEOCODER_API = process.env.GOOGLE_GEOCODING_API,
-    geocoder = NodeGeocoder({
-        provider: 'google',
-        httpAdapter: 'https', // Default
-        apiKey: GEOCODER_API, // for Mapquest, OpenCage, Google Premier
-        formatter: null         // 'gpx', 'string', ...
-    });
+const cache = CacheManager.caching({ store: 'memory', max: 1000, ttl: 36000 });
+const GEOCODER_API = process.env.GOOGLE_GEOCODING_API;
+const geocoder = NodeGeocoder({
+    provider:    'google',
+    httpAdapter: 'https',      // Default
+    apiKey:      GEOCODER_API, // for Mapquest, OpenCage, Google Premier
+    formatter:   null          // 'gpx', 'string', ...
+});
 
-// turns coordinates into key strings used to bust the match new requests to cached responses
+// turns coordinates into key strings used to bust the match new requests to cached values
 // might be a good idea to add a precision limit to reduce cache misses
-let coordsToCacheKey = (lat, long) => {
-    return lat + ', ' + long;
-};
+const locString = (lat, lon) => `${lat}, ${lon}`;
 
 // helper to filter json down
 function queryJson(json, query){
-    let res =  jsonQuery(query, {data: json}).value;
-    if (typeof(res) === 'object') {
-        res = JSON.stringify(res);
-    }
+    const res = jsonQuery(query, { data: json }).value;
+    if (res === undefined || res === null) throw Error('no results');
     return res;
 }
 
-// reverse geocoding helper, doesn't return a promise. handles sending of response.
-let reverseGeocode = (lat, lon, response, query)=>{
-    cache.wrap(coordsToCacheKey(lat, lon) + query, cacheCallback => {
-        logger.trace('Geocoding (not cached)', lat, lon);
-        geocoder.reverse({lat, lon})
-            .then(function(res) {
-                // only interested in the first match
-                res = queryJson(res[0], query);
-                if (res === null) return cacheCallback('not found', null);
-                // send the response to user
-                return cacheCallback(null, res);
-            })
-            .catch((err) => {
-                logger.error(err);
-                return cacheCallback('Error in reverse geocoding', null);
-            });
-    }, (err, results) => {
-        if(results){
-            logger.trace('answering with',results);
-            response.send(results);
-        } else {
-            showError(err, response);
+async function reverseGeocode(lat, lon, query) {
+    return await cache.wrap(locString(lat, lon) + query, async () => {
+        logger.trace('Geocoding (not cached)', lat, lon, query);
+        try {
+            const res = await geocoder.reverse({ lat, lon });
+            return queryJson(res[0], query); // only interested in the first match
+        } catch (e) {
+            throw Error('Failed to geolocate');
         }
     });
-};
-
+}
 
 /**
  * Geolocates the address and returns the coordinates
  * @param {String} address target address
  * @returns {Object} structured data representing the location of the address
  */
-GeoLocationRPC.geolocate = function (address) {
-    let response = this.response;
-
-    logger.trace('Geocoding', address);
-    return cache.wrap(address, () => {
-        return geocoder.geocode(address)
-            .then(function(res) {
-                logger.trace(res);
-                return [['latitude', res[0].latitude], ['longitude', res[0].longitude]];
-            });
-    })
-        .catch(function(err) {
-            logger.error('Error in geocoding', err);
-            showError('Failed to geocode',response);
-        });
+GeoLocationRPC.geolocate = async function (address) {
+    return await cache.wrap(address, async () => {
+        logger.trace('Geocoding (not cached)', address);
+        try {
+            const res = await geocoder.geocode(address);
+            return { latitude: res[0].latitude, longitude: res[0].longitude };
+        } catch (e) {
+            throw Error('Failed to geolocate');
+        }
+    });
 };
 
 /**
@@ -98,8 +73,7 @@ GeoLocationRPC.geolocate = function (address) {
  * @returns {String} city name
  */
 GeoLocationRPC.city = function (latitude, longitude) {
-    reverseGeocode(latitude, longitude, this.response, '.city');
-    return null;
+    return reverseGeocode(latitude, longitude, '.city');
 };
 
 /**
@@ -113,8 +87,7 @@ GeoLocationRPC.city = function (latitude, longitude) {
  * @returns {String} county name
  */
 GeoLocationRPC['county*'] = function (latitude, longitude) {
-    reverseGeocode(latitude, longitude, this.response, '.administrativeLevels.level2long');
-    return null;
+    return reverseGeocode(latitude, longitude, '.administrativeLevels.level2long');
 };
 
 /**
@@ -128,8 +101,7 @@ GeoLocationRPC['county*'] = function (latitude, longitude) {
  * @returns {String} state name
  */
 GeoLocationRPC['state*'] = function (latitude, longitude) {
-    reverseGeocode(latitude, longitude, this.response, '.administrativeLevels.level1long');
-    return null;
+    return reverseGeocode(latitude, longitude, '.administrativeLevels.level1long');
 };
 
 /**
@@ -140,11 +112,10 @@ GeoLocationRPC['state*'] = function (latitude, longitude) {
  *
  * @param {Latitude} latitude latitude of the target location
  * @param {Longitude} longitude longitude of the target location
- * @returns {String} state name
+ * @returns {String} state code
  */
 GeoLocationRPC['stateCode*'] = function (latitude, longitude) {
-    reverseGeocode(latitude, longitude, this.response, '.administrativeLevels.level1short');
-    return null;
+    return reverseGeocode(latitude, longitude, '.administrativeLevels.level1short');
 };
 
 /**
@@ -155,8 +126,7 @@ GeoLocationRPC['stateCode*'] = function (latitude, longitude) {
  * @returns {String} country name
  */
 GeoLocationRPC.country = function (latitude, longitude) {
-    reverseGeocode(latitude, longitude, this.response, '.country');
-    return null;
+    return reverseGeocode(latitude, longitude, '.country');
 };
 
 /**
@@ -164,11 +134,10 @@ GeoLocationRPC.country = function (latitude, longitude) {
  *
  * @param {Latitude} latitude latitude of the target location
  * @param {Longitude} longitude longitude of the target location
- * @returns {String} country name
+ * @returns {String} country code
  */
 GeoLocationRPC.countryCode = function (latitude, longitude) {
-    reverseGeocode(latitude, longitude, this.response, '.countryCode');
-    return null;
+    return reverseGeocode(latitude, longitude, '.countryCode');
 };
 
 /**
@@ -176,25 +145,25 @@ GeoLocationRPC.countryCode = function (latitude, longitude) {
  *
  * @param {Latitude} latitude latitude of the target location
  * @param {Longitude} longitude longitude of the target location
+ * @returns {Array} list of administative level names
  */
-GeoLocationRPC.info = function (latitude, longitude) {
-    return geocoder.reverse({lat: latitude, lon: longitude})
-        .then( res => {
-            let levels = [];
-            res = res[0]; // we only care about the top result
-            // find and pull out all the provided admin levels
-            levels.push(res.city);
-            Object.keys(res.administrativeLevels).forEach(lvl => {
-                levels.push(res.administrativeLevels[lvl]);
-            });
-            levels.push(res.country);
-            levels.push(res.countryCode);
-            levels = levels.reverse(); // reverse so that it's big to small
-            return levels;
-        }).catch(err => {
-            logger.error(err);
-            throw(err);
-        });
+GeoLocationRPC.info = async function (latitude, longitude) {
+    const res = await geocoder.reverse({ lat: latitude, lon: longitude });
+    const { city, administrativeLevels, country, countryCode } = res[0]; // we only care about the top result
+    if (!city || !administrativeLevels || !country || !countryCode) {
+        throw Error('Failed to geolocate');
+    }
+    const levels = [];
+
+    // find and pull out all the provided admin levels
+    levels.push(city);
+    for (const level in administrativeLevels) {
+        levels.push(administrativeLevels[level]);
+    }
+    levels.push(country);
+    levels.push(countryCode);
+
+    return levels.reverse(); // reverse so that it's big to small
 };
 
 /**
@@ -202,48 +171,36 @@ GeoLocationRPC.info = function (latitude, longitude) {
  * @param {Latitude} latitude
  * @param {Longitude} longitude
  * @param {String=} keyword the keyword you want to search for, like pizza or cinema.
- * @param {Number=} radius search radius in meters (50km)
+ * @param {Number=} radius search radius in meters (default 50km)
+ * @returns {Array<Object>} list of nearby locations
  */
-GeoLocationRPC.nearbySearch = function (latitude, longitude, keyword, radius) {
-    radius = radius || 50000; // default to 50KM
-
-    let requestOptions = {
+GeoLocationRPC.nearbySearch = async function (latitude, longitude, keyword, radius = 50000) {
+    const requestOptions = {
         method: 'get',
         uri: 'https://maps.googleapis.com/maps/api/place/nearbysearch/json',
-        qs: {
-            location: latitude + ',' + longitude,
-            radius: radius,
-            // rankby: 'distance',
-            key: this.apiKey.value
-        },
-        json: true
+        qs: { location: `${latitude},${longitude}`, radius, key: this.apiKey.value },
+        json: true,
     };
-
     if (keyword) {
         requestOptions.qs.keyword = keyword;
     }
 
-    return cache.wrap(coordsToCacheKey(latitude, longitude) + keyword + radius, async () => {
+    return await cache.wrap(locString(latitude, longitude) + keyword + radius, async () => {
         const res = await rp(requestOptions);
         if (res.error_message) {
-            throw new Error(res.error_message);
+            throw Error(res.error_message);
         }
         const places = res.results;
-        // keep the 10 best results
-        const topResults = places.slice(0, 10)
-            .map(place => [
-                ['latitude', place.geometry.location.lat],
-                ['longitude', place.geometry.location.lng],
-                ['name', place.name],
-                ['types', place.types],
-            ]);
+        const topResults = places.slice(0, 10).map(place => {
+            return {
+                latitude: place.geometry.location.lat,
+                longitude: place.geometry.location.lng,
+                name: place.name,
+                types: place.types,
+            };
+        });
         return topResults;
     });
 };
-
-function showError(err, response) {
-    // if we can't answer their question return snap null
-    response.send('null');
-}
 
 module.exports = GeoLocationRPC;

--- a/test/unit/server/services/procedures/geolocation.spec.js
+++ b/test/unit/server/services/procedures/geolocation.spec.js
@@ -21,10 +21,9 @@ describe(utils.suiteName(__filename), function() {
     describe('geolocate', function() {
         it('should use proper key for caching', async () => {
             await geocoding.geolocate('Moscow, Russia');
-            const response = await geocoding.geolocate('1025 16th Ave S, Nashville, TN 37212');
-            const [[,lat], [,long]] = response;
-            assert.equal(Math.floor(lat), 36);
-            assert.equal(Math.floor(long), -87);
+            const { latitude, longitude } = await geocoding.geolocate('1025 16th Ave S, Nashville, TN 37212');
+            assert.equal(Math.floor(latitude), 36);
+            assert.equal(Math.floor(longitude), -87);
         });
     });
 


### PR DESCRIPTION
I noticed in the python interface some type errors from `Geolocation`. It turns out some of the rpcs were violating their return types by returning `null` or `undefined` on the failure cases of the cache callback logic. This PR fixes these type errors by throwing on failure cases. I also rewrote them so that we're not manually setting the response object anymore. Also everything is async now rather than callback-based. (And the old code was getting unhandled exceptions on invalid locations since they were throwing inside the callbacks - that's fixed by async now)