### PR TITLE
3291 Fix Vaccination RPCs

### DIFF
--- a/src/server/services/procedures/covid-19/types.js
+++ b/src/server/services/procedures/covid-19/types.js
@@ -21,4 +21,4 @@ function registerTypes() {
     });
 }
 
-module.exports = {registerTypes};
+module.exports = {registerTypes, VaccineCategories};

--- a/src/server/services/procedures/covid-19/vaccination/vaccination-data-source.js
+++ b/src/server/services/procedures/covid-19/vaccination/vaccination-data-source.js
@@ -22,7 +22,8 @@ function dictPathOrEmptyInit(dict, path) {
 
 function isGoodData(data){
     for(const key in data) {
-        if (!data[key]) return false;
+        const v = data[key];
+        if (v === undefined || v === null || v === '' || isNaN(v)) return false;
     }
     return true;
 }
@@ -99,33 +100,38 @@ async function getWorldData() {
     logger.info('download complete - restructuring data');
 
     const res = {};
-    let first = true;
-    for (const row of resp.data.split(/\r?\n/)) {
-        if(first) {
-            first = false;
-            continue;
+    const rows = resp.data.split(/\r?\n/);
+    const fields = rows.shift().split(',').map(s => s.replace(/[-_\s]+/g, ' ').trim());
+    const desired_fields = [
+        'total vaccinations',
+        'people vaccinated',
+        'people fully vaccinated',
+        'daily vaccinations raw',
+        'daily vaccinations',
+        'total vaccinations per hundred',
+        'people vaccinated per hundred',
+        'people fully vaccinated per hundred',
+        'daily vaccinations per million',
+    ];
+    for (const row of rows) {
+        const rawVals = row.split(',');
+        if (rawVals.length !== fields.length) continue; // bad csv (unlikely), skip the row
+
+        const vals = {};
+        for (let i = 0; i < fields.length; ++i) {
+            vals[fields[i]] = rawVals[i];
         }
 
-        const vals = row.split(',');
-        if (vals.length !== 12) continue;
-
-        const country = vals[0];
-        const rawDate = vals[2].split('-');
+        const country = vals['location'];
+        const rawDate = vals['date'].split('-');
         const date = `${rawDate[1]}/${rawDate[2]}/${rawDate[0]}`;
 
-        const data = {
-            'total vaccinations': parseFloat(vals[3]),
-            'people vaccinated': parseFloat(vals[4]),
-            'people fully vaccinated': parseFloat(vals[5]),
-            'daily vaccinations raw': parseFloat(vals[6]),
-            'daily vaccinations': parseFloat(vals[7]),
-            'total vaccinations per hundred': parseFloat(vals[8]),
-            'people vaccinated per hundred': parseFloat(vals[9]),
-            'people fully vaccinated per hundred':parseFloat(vals[10]),
-            'daily vaccinations per million':parseFloat(vals[11]),
-        };
-
+        const data = {};
+        for (const field of desired_fields) {
+            data[field] = parseFloat(vals[field]);
+        }
         if (!isGoodData(data)) continue;
+
         const entry = dictPathOrEmptyInit(res, [country, date]);
         for (const key in data) {
             entry[key] = data[key];

--- a/src/server/services/procedures/covid-19/vaccination/vaccination-data-source.js
+++ b/src/server/services/procedures/covid-19/vaccination/vaccination-data-source.js
@@ -146,7 +146,7 @@ async function getWorldData() {
     }
 
     if (goodRows === 0) {
-        logger.error(`World Data got no data (all rows were invalid)`);
+        logger.error('World Data got no data (all rows were invalid)');
     } else if (goodRows !== rows.length) {
         const bad = rows.length - goodRows;
         logger.warn(`World Data: ${bad} of ${rows.length} rows (${100 * bad / rows.length}%) were discarded due to incomplete data`);

--- a/test/unit/server/services/procedures/covid-19/vax-data.spec.js
+++ b/test/unit/server/services/procedures/covid-19/vax-data.spec.js
@@ -1,0 +1,11 @@
+const utils = require('../../../../../assets/utils');
+
+describe(utils.suiteName(__filename), function() {
+    const VaxData = utils.reqSrc('services/procedures/covid-19/vaccination/vaccination-data-source.js');
+    const assert = require('assert');
+
+    it('should get data non-empty data from the world data provider', async function() {
+        const res = await VaxData.getWorldData();
+        assert(res.length !== 0);
+    });
+});


### PR DESCRIPTION
Closes #3291. The vaccination categories RPC not working was simply due to a missing export (kinda surprised node didn't complain about that directly).

The vaccination data RPC was returning empty list for everything. Turns out that's because the datasource it was dynamically fetching at runtime changed their csv file structure. I've hardened the parser against future changes by restructuring each row as an object based on the header fields.

There's still the issue that came up in the meeting about needing to fetch all the data just to get the country list, but since it's all in a single CSV file (which we cache), there's not much we can do about it (assuming at least one call to actually fetch data is made). Also the file itself is only 4MB (currently). I couldn't reproduce the crash that Akos had earlier - based on what was wrong here, it should have just returned empty list - maybe unrelated?