### PR TITLE
Static RPC Type Sanitizing

### DIFF
--- a/src/server/services/input-types.js
+++ b/src/server/services/input-types.js
@@ -213,6 +213,25 @@ defineType({
 });
 
 defineType({
+    name: 'Union',
+    displayName: 'AnyOf',
+    description: 'A value which is any of the listed allowed types.',
+    baseType: 'Any',
+    parser: async (input, params=[]) => {
+        let errorMsg = 'Input was not one of the allowed types:';
+        for (const ty of params) {
+            const parser = getTypeParser(ty);
+            try {
+                return await parser(input);
+            } catch (e) {
+                errorMsg += '\n' + e;
+            }
+        }
+        throw Error(errorMsg);
+    },
+});
+
+defineType({
     name: 'Array',
     displayName: 'List',
     description: 'A list of (zero or more) values.',
@@ -322,6 +341,14 @@ defineType({
         await types.Function(blockXml, _params, ctx); // check that it compiles
         return blockXml;
     },
+});
+
+// in the future, this should have a useful parser of some kind
+// not an issue for now since only 1 RPC takes images as input
+defineType({
+    name: 'Image',
+    description: 'Any image',
+    baseType: 'Any',
 });
 
 defineType({

--- a/src/server/services/procedures/hurricane-data/hurricane-data.js
+++ b/src/server/services/procedures/hurricane-data/hurricane-data.js
@@ -116,7 +116,7 @@ async function getData() {
 /**
  * Get hurricane data including location, maximum winds, and central pressure.
  *
- * @param {string} name - name of the hurricane
+ * @param {String} name - name of the hurricane
  * @param {BoundedNumber<1850,2020>} year - year that the hurricane occurred in
  * @returns {Array<Object>} - All recorded data for the given hurricane
  */

--- a/src/server/services/procedures/ice-core-data/ice-core-data.js
+++ b/src/server/services/procedures/ice-core-data/ice-core-data.js
@@ -189,7 +189,7 @@ IceCoreData.getIceCoreNames = function() {
 /**
  * Get a table showing the amount of available data for each ice core.
  *
- * @returns {Table} data availability table
+ * @returns {Array<Array>} data availability table
  */
 IceCoreData.getDataAvailability = async function() {
     const dataStatistics = await IceCoreMetadata.find({}).lean();

--- a/src/server/services/procedures/iotscape/iotscape.js
+++ b/src/server/services/procedures/iotscape/iotscape.js
@@ -59,7 +59,7 @@ IoTScape.getServices = IoTScapeServices.getServices;
 
 /**
  * List the message types associated with a service
- * @param {string} service Name of service to get events for
+ * @param {String} service Name of service to get events for
  */
 IoTScape.getMessageTypes = function(service){
     if(!IoTScapeServices.serviceExists(service)){

--- a/src/server/services/procedures/new-york-times/new-york-times.js
+++ b/src/server/services/procedures/new-york-times/new-york-times.js
@@ -294,7 +294,7 @@ NewYorkTimes.searchConcepts = async function(query) {
  * @param{Object} concept
  * @param{String} concept.name
  * @param{ConceptType} concept.type
- * @returns{ConceptInfo}
+ * @returns{Object}
  */
 NewYorkTimes.getConceptInfo = async function(concept) {
     const response = await this._requestData({

--- a/src/server/services/procedures/phone-iot/phone-iot.js
+++ b/src/server/services/procedures/phone-iot/phone-iot.js
@@ -184,7 +184,7 @@ PhoneIoT.prototype._heartbeat = function () {
 
 /**
  * Returns the MAC addresses of the registered devices for this client.
- * @returns {array} the list of registered devices
+ * @returns {Array<String>} the list of registered devices
  */
 PhoneIoT.prototype._getRegistered = function () {
     const state = this._state;
@@ -202,7 +202,7 @@ PhoneIoT.prototype._getRegistered = function () {
 /**
  * Returns the addresses of all authorized devices.
  * @category Utility
- * @returns {array}
+ * @returns {Array<String>}
  */
 PhoneIoT.prototype._getDevices = async function () {
     const availableDevices = Object.keys(this._devices);
@@ -796,7 +796,7 @@ if (PHONE_IOT_MODE === 'native' || PHONE_IOT_MODE === 'both') {
      * @category Display
      * @param {Device} device id of the device
      * @param {String} id id of the control to read
-     * @returns {boolean} ``true`` for pressed, otherwise ``false``
+     * @returns {Boolean} ``true`` for pressed, otherwise ``false``
      */
     PhoneIoT.prototype.isPressed = function (device, id) {
         return this._passToDevice('isPressed', arguments);
@@ -809,7 +809,7 @@ if (PHONE_IOT_MODE === 'native' || PHONE_IOT_MODE === 'both') {
      * @category Display
      * @param {Device} device id of the device
      * @param {String} id id of the control to read
-     * @returns {boolean} ``true`` for checked, otherwise ``false``
+     * @returns {Boolean} ``true`` for checked, otherwise ``false``
      */
     PhoneIoT.prototype.getToggleState = function (device, id) {
         return this._passToDevice('getToggleState', arguments);
@@ -825,7 +825,7 @@ if (PHONE_IOT_MODE === 'native' || PHONE_IOT_MODE === 'both') {
      * @category Display
      * @param {Device} device id of the device
      * @param {String} id id of the control to modify
-     * @param {boolean} state new value for the toggle state
+     * @param {Boolean} state new value for the toggle state
      */
     PhoneIoT.prototype.setToggleState = function (device, id, state) {
         return this._passToDevice('setToggleState', arguments);
@@ -1170,7 +1170,7 @@ if (PHONE_IOT_MODE === 'native' || PHONE_IOT_MODE === 'both') {
      * @category Display
      * @param {Device} device id of the device
      * @param {String} id id of the image display
-     * @returns {object} the displayed image
+     * @returns {Image} the displayed image
      */
     PhoneIoT.prototype.getImage = async function (device, id) {
         const bin = await this._passToDevice('getImage', arguments);
@@ -1188,7 +1188,7 @@ if (PHONE_IOT_MODE === 'native' || PHONE_IOT_MODE === 'both') {
      * @category Display
      * @param {Device} device id of the device
      * @param {String} id the id of the control to modify
-     * @param {ImageBitmap} img the new image to display
+     * @param {Image} img the new image to display
      */
     PhoneIoT.prototype.setImage = function (device, id, img) {
         return this._passToDevice('setImage', arguments);
@@ -1197,8 +1197,8 @@ if (PHONE_IOT_MODE === 'native' || PHONE_IOT_MODE === 'both') {
     // /**
     //  * Sets the total message limit for the given device.
     //  * @param {Device} device id of the device
-    //  * @param {number} rate number of messages per seconds
-    //  * @returns {boolean} True if the device was found
+    //  * @param {Number} rate number of messages per seconds
+    //  * @returns {Boolean} True if the device was found
     //  */
     // PhoneIoT.prototype.setTotalRate = function (device, rate) {
     //     return this._passToDevice('setTotalRate', arguments);
@@ -1207,9 +1207,9 @@ if (PHONE_IOT_MODE === 'native' || PHONE_IOT_MODE === 'both') {
     // /**
     //  * Sets the client message limit and penalty for the given device.
     //  * @param {Device} device id of the device
-    //  * @param {number} rate number of messages per seconds
-    //  * @param {number} penalty number seconds of penalty if rate is violated
-    //  * @returns {boolean} True if the device was found
+    //  * @param {Number} rate number of messages per seconds
+    //  * @param {Number} penalty number seconds of penalty if rate is violated
+    //  * @returns {Boolean} True if the device was found
     //  */
     // PhoneIoT.prototype.setClientRate = function (device, rate, penalty) {
     //     return this._passToDevice('setClientRate', arguments);

--- a/src/server/services/procedures/roboscape/roboscape.js
+++ b/src/server/services/procedures/roboscape/roboscape.js
@@ -132,7 +132,7 @@ RoboScape.prototype._getRegistered = function () {
 
 /**
  * Registers for receiving messages from the given robots.
- * @param {array} robots one or a list of robots
+ * @param {Union<Array<String>,String>} robots one or a list of robots
  * @deprecated
  */
 RoboScape.prototype.eavesdrop = function (robots) {
@@ -141,7 +141,7 @@ RoboScape.prototype.eavesdrop = function (robots) {
 
 /**
  * Registers for receiving messages from the given robots.
- * @param {array} robots one or a list of robots
+ * @param {Union<Array<String>,String>} robots one or a list of robots
  */
 RoboScape.prototype.listen = async function (robots) {
     var state = this._state;
@@ -172,7 +172,7 @@ RoboScape.prototype.listen = async function (robots) {
 
 /**
  * Returns the MAC addresses of all authorized robots.
- * @returns {array}
+ * @returns {Array<String>}
  */
 RoboScape.prototype.getRobots = async function () {
     const availableRobots = Object.keys(this._robots);
@@ -267,7 +267,7 @@ if (ROBOSCAPE_MODE === 'native' || ROBOSCAPE_MODE === 'both') {
     /**
      * Returns the current number of wheel ticks (1/64th rotations)
      * @param {String} robot name of the robot (matches at the end)
-     * @returns {array} the number of ticks for the left and right wheels
+     * @returns {Array<Integer>} the number of ticks for the left and right wheels
      */
     RoboScape.prototype.getTicks = function (robot) {
         return this._passToRobot('getTicks', arguments);

--- a/src/server/services/procedures/water-watch/water-watch.js
+++ b/src/server/services/procedures/water-watch/water-watch.js
@@ -25,7 +25,6 @@ function encodeQueryData(options) {
  * @param {Latitude} maxLatitude Maximum latitude of bounding box
  * @param {Longitude} minLongitude Minimum longitude of bounding box
  * @param {Longitude} maxLongitude Maximum longitude of bounding box
- * @returns {Promise<String>} Messages sent of data
  */
 waterwatch.gageHeight = function (minLatitude, maxLatitude, minLongitude, maxLongitude) {
     // https://help.waterdata.usgs.gov/codes-and-parameters/parameters
@@ -65,7 +64,6 @@ waterwatch.gageHeight = function (minLatitude, maxLatitude, minLongitude, maxLon
  * @param {Latitude} maxLatitude Maximum latitude of bounding box
  * @param {Longitude} minLongitude Minimum longitude of bounding box
  * @param {Longitude} maxLongitude Maximum longitude of bounding box
- * @returns {Promise<String>} Messages sent of data
  */
 waterwatch.streamFlow = function (minLatitude, maxLatitude, minLongitude, maxLongitude) {
     var options = {'format':'json', 'bBox': [minLongitude,minLatitude,maxLongitude,maxLatitude], 'siteType':'GL,ST,GW,GW-MW,SB-CV,LA-SH,FA-CI,FA-OF,FA-TEP,AW','siteStatus':'active','parameterCd':'00060'};
@@ -98,7 +96,6 @@ waterwatch.streamFlow = function (minLatitude, maxLatitude, minLongitude, maxLon
  * @param {Latitude} maxLatitude Maximum latitude of bounding box
  * @param {Longitude} minLongitude Minimum longitude of bounding box
  * @param {Longitude} maxLongitude Maximum longitude of bounding box
- * @returns {Promise<String>} Messages sent of data
  */
 waterwatch.waterTemp = function (minLatitude, maxLatitude, minLongitude, maxLongitude) {
     var options = {'format':'json', 'bBox':[minLongitude,minLatitude,maxLongitude,maxLatitude], 'siteType':'GL,ST,GW,GW-MW,SB-CV,LA-SH,FA-CI,FA-OF,FA-TEP,AW','siteStatus':'active','parameterCd':'00010'};

--- a/src/server/services/services-worker.js
+++ b/src/server/services/services-worker.js
@@ -69,8 +69,8 @@ class ServicesWorker {
         const fail = msg => {
             msg = `Type Checker - ${msg}`;
             if (isFS) throw Error(msg);
-            else console.error(msg);
-        }
+            else this._logger.error(msg);
+        };
         if (!docs || !Array.isArray(docs.rpcs)) {
             fail(`Failed to get rpc doc info for service ${service.serviceName}`);
             return;

--- a/test/unit/server/services/input-types.spec.js
+++ b/test/unit/server/services/input-types.spec.js
@@ -29,6 +29,26 @@ describe(utils.suiteName(__filename), function() {
         });
     });
 
+    describe('Union', function() {
+        before(() => InputTypes.defineType({
+            name: 'SomeUnion',
+            description: 'test',
+            baseType: 'Union',
+            baseParams: ['Array', 'Boolean', 'Number'],
+        }));
+
+        it('should accept the first successful parse', async () => {
+            assert.deepStrictEqual(await typesParser.SomeUnion(12), 12);
+            assert.deepStrictEqual(await typesParser.SomeUnion('12'), 12);
+            assert.deepStrictEqual(await typesParser.SomeUnion('true'), true);
+            assert.deepStrictEqual(await typesParser.SomeUnion('FALSE'), false);
+            assert.deepStrictEqual(await typesParser.SomeUnion([1,2,3]), [1,2,3]);
+        });
+        it('should reject unspecified types', async () => {
+            await assert.rejects(() => typesParser.SomeUnion('hello world'));
+        });
+    });
+
     describe('Integer', function() {
         it('should parse into JS numbers', async () => {
             let rawInput = '54';


### PR DESCRIPTION
This PR adds a validation step to the service loader that guarantees RPC arg/ret types actually exist. For instance, we had several occurrences of `array` or `string` which wouldn't properly get parsed. For fs services, this will throw a hard error on startup, so we can't accidentally make these errors in the future. Non-fs services will log an error, but otherwise permit it.

The Roboscape service had rpcs that took `string` (unparsed) and internally wanted it to either be an array of strings or a single string. To handle this with proper typing, I introduced a new type to express this as `Union<Array<String>,String>` (which displays in the docs as `AnyOf` rather than `Union`). It takes one or more types and returns the first successful parse, or an error stating why every option failed.

Also added an `Image` type since that was used in several places and is needed for the python code generator, but currently it doesn't actually do anything.