### PR TITLE
geoloc timezone #3323

### DIFF
--- a/src/server/services/procedures/utils/api-key.js
+++ b/src/server/services/procedures/utils/api-key.js
@@ -19,6 +19,11 @@ class ApiKey {
     }
 }
 
+module.exports.TimezoneDBKey = new ApiKey(
+    'TimezoneDB',
+    'https://timezonedb.com/register',
+    'TIMEZONEDB_KEY'
+);
 module.exports.NewYorkPublicLibraryKey = new ApiKey(
     'New York Public Library',
     'http://api.repo.nypl.org/sign_up' // key is 'Authentication Token' from account info

--- a/test/unit/server/services/input-types.spec.js
+++ b/test/unit/server/services/input-types.spec.js
@@ -148,6 +148,47 @@ describe(utils.suiteName(__filename), function() {
         });
     });
 
+    describe('Tuple', function() {
+        before(() => {
+            InputTypes.defineType({
+                name: 'SomeTupleA',
+                description: 'test',
+                baseType: 'Tuple',
+                baseParams: ['Integer'],
+            });
+            InputTypes.defineType({
+                name: 'SomeTupleB',
+                description: 'test',
+                baseType: 'Tuple',
+                baseParams: ['Integer', 'String'],
+            });
+            InputTypes.defineType({
+                name: 'SomeTupleC',
+                description: 'test',
+                baseType: 'Tuple',
+                baseParams: ['Integer', 'Array', 'String'],
+            });
+        });
+
+        it('should throw for non-array input', async () => {
+            await utils.shouldThrow(() => typesParser.SomeTupleA(12));
+            await utils.shouldThrow(() => typesParser.SomeTupleA('12'));
+            assert.deepStrictEqual(await typesParser.SomeTupleA(['12']), [12]);
+        });
+        it('should throw on wrong arity input', async () => {
+            await utils.shouldThrow(() => typesParser.SomeTupleB([]));
+            await utils.shouldThrow(() => typesParser.SomeTupleB(['12']));
+            assert.deepStrictEqual(await typesParser.SomeTupleB(['12', 'hello']), [12, 'hello']);
+            await utils.shouldThrow(() => typesParser.SomeTupleB(['12', 'hello', []]));
+        });
+        it('should accept only correct type sequence', async () => {
+            await utils.shouldThrow(() => typesParser.SomeTupleC(['12.4', [], 'hello']));
+            await utils.shouldThrow(() => typesParser.SomeTupleC(['12', '67', 'hello']));
+            await utils.shouldThrow(() => typesParser.SomeTupleC(['12', '67', 'hello']));
+            assert.deepStrictEqual(await typesParser.SomeTupleC(['12', ['finally'], 'hello']), [12, ['finally'], 'hello']);
+        });
+    });
+
     describe('Object', function() {
         it('should throw error if input has a pair of size 0', async () => {
             let rawInput = [[], ['a', 234],['name', 'Hamid'], ['connections', ['b','c','d']]];

--- a/test/unit/server/services/procedures/geolocation.spec.js
+++ b/test/unit/server/services/procedures/geolocation.spec.js
@@ -17,7 +17,9 @@ describe(utils.suiteName(__filename), function() {
         ['stateCode*', ['latitude', 'longitude']],
         ['county*', ['latitude', 'longitude']],
         ['info', ['latitude', 'longitude']],
-        ['geolocate', ['address']]
+        ['geolocate', ['address']],
+        ['timezone', ['address']],
+        ['streetAddress', ['address']],
     ]);
 
     describe('geolocate', function() {


### PR DESCRIPTION
Closes #3323. This adds RPCs `timezone` and `streetAddress` to `Geolocation`. `timezone` takes as input either a list of `[lat,long]` or a string to lookup through `geolocate`. To facilitate this, I also added an input type called `Tuple`. `streetAddress` takes an address string and pipes it through `geolocate` to get the formatted address, which was conveniently already available after a tiny refactor.

Note: a new api key is needed just for the `timezone` RPC, but it looks like the required key machinery we have set up atm doesn't allow multiple keys.