### PR TITLE
Doc links for inner types #3307

### DIFF
--- a/bin/build-docs.js
+++ b/bin/build-docs.js
@@ -31,7 +31,7 @@ function isObject(type) {
     return type && type.name && type.name.toLowerCase() === 'object';
 }
 function linkType(dispName) {
-    return `\`${dispName} </docs/fundamentals/rpc-arg-types.html#${dispName}>\`__`
+    return `\`${dispName} </docs/fundamentals/rpc-arg-types.html#${dispName}>\`__`;
 }
 function getTypeString(type, link = false) {
     if (link === true) {
@@ -42,14 +42,12 @@ function getTypeString(type, link = false) {
 
     if (type.name === undefined) {
         const rawName = type.toString();
-        if (!link) return rawName;
-
         const ty = INPUT_TYPES[rawName];
-        if (!ty) return;
-
-        const res = linkType(ty.displayName || rawName);
-        if (!link.includes(res)) link.push(res);
-        return;
+        if (link && ty) {
+            const res = linkType(ty.displayName || rawName);
+            if (!link.includes(res)) link.push(res);
+        }
+        return rawName;
     }
 
     const params = type.params || [];
@@ -61,11 +59,11 @@ function getTypeString(type, link = false) {
             if (!link.includes(res)) link.push(res);
         }
         for (const sub of params) getTypeString(sub, link);
-        return;
     }
-
-    if (isObject(type)) return 'Object';
-    return params.length ? `${name}<${params.map(x => getTypeString(x)).join(', ')}>` : name;
+    else {
+        if (isObject(type)) return 'Object';
+        return params.length ? `${name}<${params.map(x => getTypeString(x)).join(', ')}>` : name;
+    }
 }
 function getParamString(param, link = false) {
     if (link) return param.type ? getTypeString(param.type, true) : '';

--- a/bin/build-docs.js
+++ b/bin/build-docs.js
@@ -34,29 +34,34 @@ function linkType(dispName) {
     return `\`${dispName} </docs/fundamentals/rpc-arg-types.html#${dispName}>\`__`
 }
 function getTypeString(type, link = false) {
+    if (link === true) {
+        const links = [];
+        getTypeString(type, links);
+        return links.join(' | ');
+    }
+
     if (type.name === undefined) {
         const rawName = type.toString();
         if (!link) return rawName;
 
         const ty = INPUT_TYPES[rawName];
-        if (!ty) return '';
+        if (!ty) return;
 
-        return linkType(ty.displayName || rawName);
+        const res = linkType(ty.displayName || rawName);
+        if (!link.includes(res)) link.push(res);
+        return;
     }
 
     const params = type.params || [];
     const name = (INPUT_TYPES[type.name] || {}).displayName || type.name;
 
     if (link) {
-        const links = [];
         if (INPUT_TYPES[type.name]) {
-            links.push(linkType(name));
+            const res = linkType(name);
+            if (!link.includes(res)) link.push(res);
         }
-        for (const sub of params) {
-            const t = getTypeString(sub, true);
-            if (t && !links.includes(t)) links.push(t);
-        }
-        return links.join(' | ');
+        for (const sub of params) getTypeString(sub, link);
+        return;
     }
 
     if (isObject(type)) return 'Object';


### PR DESCRIPTION
Closes #3307. Adds doc links for inner types. RST doesn't allow links inside of (inline) code literals, and we can't (easily) switch to raw html since RST requires a double new line to start a protocol block and most of these links are inside of bullet points (new lines would break them). Instead, this adds a parenthesized list of named type links after the code-formatted block.

Example: 
![image](https://user-images.githubusercontent.com/37459229/150283874-1fcffa62-6d86-4ca8-9bee-6a4f1eb3bfc5.png)

Filtering is performed so that non-types like in `BoundedNumber<0, 10>` don't get linked. Also, the links appear in the same order as in the type declaration, but are deduped.