### PR TITLE
Use defined project ID when setting up service instances

### DIFF
--- a/src/server/services/services-worker.js
+++ b/src/server/services/services-worker.js
@@ -224,7 +224,7 @@ class ServicesWorker {
     }
 
     invoke(context, serviceName, rpcName, args) {
-        const rpc = this.getServiceInstance(serviceName, context.projectId);
+        const rpc = this.getServiceInstance(serviceName, context.caller.projectId);
         const ctx = Object.create(rpc);
         Object.assign(ctx, context);
         return this.callRPC(rpcName, ctx, args);


### PR DESCRIPTION
Close #3358 

@brollb I'm not sure if this is the project ID you'd prefer it use (there's also one from the socket RemoteClient, although I think they should be the same), but the issue was that the `projectId` it was using was coming up undefined. After changing this it seems to correctly make separate service instances again.