### PR TITLE
Extended CloudVariables RPCs

### DIFF
--- a/src/server/services/procedures/cloud-variables/cloud-variables.js
+++ b/src/server/services/procedures/cloud-variables/cloud-variables.js
@@ -456,7 +456,7 @@ CloudVariables._getListenBucket = function (name) {
     let bucket = globalListeners[name];
     if (!bucket) bucket = globalListeners[name] = {};
     return bucket;
-}
+};
 CloudVariables._getUserListenBucket = function (name) {
     const user = this.caller.username;
     let userBucket = userListeners[user];
@@ -465,7 +465,7 @@ CloudVariables._getUserListenBucket = function (name) {
     let bucket = userBucket[name];
     if (!bucket) bucket = userBucket[name] = {};
     return bucket;
-}
+};
 
 /**
  * Registers your client to receive messages each time the variable value is updated.

--- a/src/server/services/procedures/cloud-variables/cloud-variables.js
+++ b/src/server/services/procedures/cloud-variables/cloud-variables.js
@@ -408,50 +408,6 @@ CloudVariables.deleteUserVariable = async function(name) {
     delete (userListeners[username] || {})[name];
 };
 
-/**
- * Equivalent to calling :func:`CloudVariables.lockVariable` followed by :func:`CloudVariables.getVariable`.
- * @param {String} name Variable name
- * @param {String=} password Password (if password-protected)
- */
-CloudVariables.lockAndGetVariable = async function(name, password) {
-    await this.lockVariable(name, password);
-    return await this.getVariable(name, password);
-};
-
-/**
- * Equivalent to calling :func:`CloudVariables.setVariable` followed by :func:`CloudVariables.unlockVariable`.
- * @param {String} name Variable name
- * @param {Any} value Value to store in variable
- * @param {String=} password Password (if password-protected)
- */
-CloudVariables.setAndUnlockVariable = async function(name, value, password) {
-    await this.setVariable(name, value, password);
-    await this.unlockVariable(name, password);
-};
-
-/**
- * Sets the variable to the given value and returns the previous value.
- * @param {String} name Variable name
- * @param {Any} value Value to store in variable
- * @param {String=} password Password (if password-protected)
- */
-CloudVariables.getAndSetVariable = async function(name, value, password) {
-    const res = await this.getVariable(name, password);
-    await this.setVariable(name, value, password);
-    return res;
-};
-
-/**
- * Sets the variable to the given value and returns the previous value.
- * @param {String} name Variable name
- * @param {Any} value Value to store in variable
- */
-CloudVariables.getAndSetUserVariable = async function(name, value) {
-    const res = await this.getUserVariable(name);
-    await this.setUserVariable(name, value);
-    return res;
-};
-
 CloudVariables._getListenBucket = function (name) {
     let bucket = globalListeners[name];
     if (!bucket) bucket = globalListeners[name] = {};
@@ -481,7 +437,7 @@ CloudVariables._getUserListenBucket = function (name) {
  * - ``value`` - the new value of the variable
  * 
  * @param {String} name Variable name
- * @param {Any} msgType Message type to send each time the variable is updated
+ * @param {String} msgType Message type to send each time the variable is updated
  * @param {String=} password Password (if password-protected)
  */
 CloudVariables.listenToVariable = async function(name, msgType, password) {

--- a/test/unit/server/services/input-types.spec.js
+++ b/test/unit/server/services/input-types.spec.js
@@ -234,6 +234,16 @@ describe(utils.suiteName(__filename), function() {
         });
     });
 
+    describe('Duration', function() {
+        const parse = typesParser.Duration;
+
+        it('should parse chained durations', async () => {
+            assert.deepStrictEqual(await parse(' 12d  '), 12*24*60*60*1000);
+            assert.deepStrictEqual(await parse(' 12d  -  5    hrs  '), 12*24*60*60*1000 - 5*60*60*1000);
+            assert.deepStrictEqual(await parse(' 5s - 10s + 12ms'), 5*1000 - 10*1000 + 12);
+        });
+    });
+
     describe('Object', function() {
         it('should throw error if input has a pair of size 0', async () => {
             let rawInput = [[], ['a', 234],['name', 'Hamid'], ['connections', ['b','c','d']]];

--- a/test/unit/server/services/procedures/cloud-variables.spec.js
+++ b/test/unit/server/services/procedures/cloud-variables.spec.js
@@ -21,10 +21,6 @@ describe(utils.suiteName(__filename), function() {
         ['getUserVariable', ['name']],
         ['setUserVariable', ['name', 'value']],
         ['deleteUserVariable', ['name']],
-        ['lockAndGetVariable', ['name', 'password']],
-        ['setAndUnlockVariable', ['name', 'value', 'password']],
-        ['getAndSetVariable', ['name', 'value', 'password']],
-        ['getAndSetUserVariable', ['name', 'value']],
         ['listenToVariable', ['name', 'msgType', 'password']],
         ['listenToUserVariable', ['name', 'msgType']],
     ]);

--- a/test/unit/server/services/procedures/cloud-variables.spec.js
+++ b/test/unit/server/services/procedures/cloud-variables.spec.js
@@ -21,8 +21,8 @@ describe(utils.suiteName(__filename), function() {
         ['getUserVariable', ['name']],
         ['setUserVariable', ['name', 'value']],
         ['deleteUserVariable', ['name']],
-        ['listenToVariable', ['name', 'msgType', 'password']],
-        ['listenToUserVariable', ['name', 'msgType']],
+        ['listenToVariable', ['name', 'msgType', 'password', 'duration']],
+        ['listenToUserVariable', ['name', 'msgType', 'duration']],
     ]);
 
     let counter = 0;

--- a/test/unit/server/services/procedures/cloud-variables.spec.js
+++ b/test/unit/server/services/procedures/cloud-variables.spec.js
@@ -21,6 +21,12 @@ describe(utils.suiteName(__filename), function() {
         ['getUserVariable', ['name']],
         ['setUserVariable', ['name', 'value']],
         ['deleteUserVariable', ['name']],
+        ['lockAndGetVariable', ['name', 'password']],
+        ['setAndUnlockVariable', ['name', 'value', 'password']],
+        ['getAndSetVariable', ['name', 'value', 'password']],
+        ['getAndSetUserVariable', ['name', 'value']],
+        ['listenToVariable', ['name', 'msgType', 'password']],
+        ['listenToUserVariable', ['name', 'msgType']],
     ]);
 
     let counter = 0;
@@ -53,6 +59,16 @@ describe(utils.suiteName(__filename), function() {
                 .then(() => cloudvariables.deleteVariable(name))
                 .then(() => cloudvariables.getVariable(name))
                 .catch(err => assert(err.message.includes('not found')));
+        });
+
+        it('should gracefully fail to delete non-existant variables', async function() {
+            const name = newVar();
+            try {
+                await cloudvariables.deleteVariable(name);
+                assert(false, 'should have thrown');
+            } catch (e) {
+                assert(e.message.includes('not found'));
+            }
         });
 
         it('should not get/set variables w/ bad password', function() {


### PR DESCRIPTION
- Adds a few fused operations like `lockAndGet`, `setAndUnlock`, and `getAndSet` for both global and user variables.
- Adds the ability to asynchronously listen for updates to a variable (global or user) via message passing
  - Only allowed after successful auth
  - Updates stop when the variable is deleted (prevents bypassing a new password)

Updated the service impl to use `async`/`await` instead of `.then`/`.catch`.

Also fixes a bug where deleting an undefined variable was having a null reference error. Now this gives a nice error message. Since it lacked a test case, there's no current standard for this, so we could just as well make it a no-op (I'm fine either way).

---

These might become important soon, as PyBlox is using the `CloudVariables` service to emulate rooms by storing global addresses and role metadata in a cloud var (one per room) and resolving role names in the PyBlox client. The async listening with messages is important because currently the PyBlox client has to periodically query the server for updates - I have this cached to run at most `1Hz`, but it's still an `O(t)` cost to maintain even a steady state room. And the fused ops would just be nice since it'll speed up the Arc logic PyBlox is using for room lifetime management.