### PR TITLE
phoneiot msg update

### DIFF
--- a/src/server/services/procedures/phone-iot/common.js
+++ b/src/server/services/procedures/phone-iot/common.js
@@ -148,7 +148,8 @@ common.SENSOR_PACKERS = {
     'microphoneLevel': vals => { return { volume: vals[0] }; },
     'proximity': vals => { return { distance: vals[0] }; },
     'stepCount': vals => { return { count: vals[0] }; },
-    'location': vals => { return { latitude: vals[0], longitude: vals[1], bearing: vals[2], altitude: vals[3] }; },
+    // also send 'bearing' for backwards compat - now correctly called 'heading'
+    'location': vals => { return { latitude: vals[0], longitude: vals[1], heading: vals[2], bearing: vals[2], altitude: vals[3] }; },
 };
 common.DEPRECATED_SENSORS = new Set([
     'rotation', 'gameRotation',

--- a/src/server/services/procedures/phone-iot/device.js
+++ b/src/server/services/procedures/phone-iot/device.js
@@ -45,7 +45,7 @@ const common = require('./common');
 // v - image box updated
 // W - get toggle state
 // w - set toggle state
-// X - location (latlong + bearing + altitude)
+// X - location (latlong + heading + altitude)
 // Y - gyroscope
 // y - add custom radiobutton control
 // Z - add custom checkbox control
@@ -825,7 +825,7 @@ Device.prototype._getLocationRaw = async function (device, args, clientId) {
 Device.prototype.getLocation = async function (device, args, clientId) {
     return throwIfErr(await this._getLocationRaw(device, args, clientId)).vals.slice(0, 2);
 };
-Device.prototype.getBearing = async function (device, args, clientId) {
+Device.prototype.getGPSHeading = async function (device, args, clientId) {
     return throwIfErr(await this._getLocationRaw(device, args, clientId)).vals[2];
 };
 Device.prototype.getAltitude = async function (device, args, clientId) {
@@ -1083,7 +1083,7 @@ Device.prototype.onMessage = function (message) {
     else if (command === 'U') this._sendControlResult('addimagedisplay', message);
     else if (command === 'b') {
         const id = message.toString('utf8', 11);
-        this._fireRawCustomEvent(id, {id});
+        this._fireRawCustomEvent(id, { device: this.id, id });
     }
     else if (command === 'n') {
         if (message.length >= 24) {
@@ -1093,7 +1093,7 @@ Device.prototype.onMessage = function (message) {
                 this.controlUpdateTimestamps[id] = time;
 
                 const tag = parseClickTag(message[15]);
-                if (tag) this._fireRawCustomEvent(id, { id, x: message.readFloatBE(16), y: message.readFloatBE(20), tag });
+                if (tag) this._fireRawCustomEvent(id, { device: this.id, id, x: message.readFloatBE(16), y: message.readFloatBE(20), tag });
             }
         }
     }
@@ -1105,7 +1105,7 @@ Device.prototype.onMessage = function (message) {
                 this.controlUpdateTimestamps[id] = time;
 
                 const tag = parseClickTag(message[15]);
-                if (tag) this._fireRawCustomEvent(id, { id, level: message.readFloatBE(16), tag });
+                if (tag) this._fireRawCustomEvent(id, { device: this.id, id, level: message.readFloatBE(16), tag });
             }
         }
     }
@@ -1115,7 +1115,7 @@ Device.prototype.onMessage = function (message) {
             if (message.length >= 12 + idlen) {
                 const id = message.toString('utf8', 12, 12 + idlen);
                 const text = message.toString('utf8', 12 + idlen);
-                this._fireRawCustomEvent(id, {id, text});
+                this._fireRawCustomEvent(id, { device: this.id, id, text });
             }
         }
     }
@@ -1123,7 +1123,7 @@ Device.prototype.onMessage = function (message) {
         if (message.length >= 12) {
             const state = message[11] !== 0;
             const id = message.toString('utf8', 12, message.length);
-            this._fireRawCustomEvent(id, { id, state });
+            this._fireRawCustomEvent(id, { device: this.id, id, state });
         }
     }
     else if (command === 'W') this._sendBoolStateResult('getToggleState', 'toggleable', message);

--- a/src/server/services/procedures/phone-iot/phone-iot.js
+++ b/src/server/services/procedures/phone-iot/phone-iot.js
@@ -333,7 +333,7 @@ if (PHONE_IOT_MODE === 'native' || PHONE_IOT_MODE === 'both') {
      * @param {String=} text text to display on the button (default empty)
      * @param {Object=} options Additional options
      * @param {String=} options.id The id to use for the control. If not specified, a new one will be automatically generated.
-     * @param {String=} options.event The name of a message type to be sent each time the button is pressed. You must call :func:`PhoneIoT.listenToGUI` to actually receive these messages. If not specified, no event is sent. Message fields: ``id``.
+     * @param {String=} options.event The name of a message type to be sent each time the button is pressed. You must call :func:`PhoneIoT.listenToGUI` to actually receive these messages. If not specified, no event is sent. Message fields: ``device``, ``id``.
      * @param {ButtonStyle=} options.style The display style of the button on the screen. This can be ``rectangle`` (default), ``ellipse``, ``square``, or ``circle``. If ``square`` or ``circle`` is used, the height of the control is ignored (height equals width).
      * @param {Color=} options.color The background color of the button.
      * @param {Color=} options.textColor The text color of the button.
@@ -366,7 +366,7 @@ if (PHONE_IOT_MODE === 'native' || PHONE_IOT_MODE === 'both') {
      * @param {Size} height Height of the image display (percentage).
      * @param {Object=} options Additional options
      * @param {String=} options.id The id to use for the control. If not specified, a new one will be automatically generated.
-     * @param {String=} options.event The name of a message type to be sent each time the user updates the content (only possible if ``readonly = false``). You must call :func:`PhoneIoT.listenToGUI` to actually receive these messages. If not specified, no event is sent. Message fields: ``id``.
+     * @param {String=} options.event The name of a message type to be sent each time the user updates the content (only possible if ``readonly = false``). You must call :func:`PhoneIoT.listenToGUI` to actually receive these messages. If not specified, no event is sent. Message fields: ``device``, ``id``.
      * @param {Boolean=} options.readonly If set to ``true`` (default), the user will not be able to edit the content; however, you will still be able to do so programmatically via :func:`PhoneIoT.setImage`. Defaults to ``true``.
      * @param {Boolean=} options.landscape If set to ``true``, rotates the image display ``90`` degrees around its top left corner.
      * @param {Fit=} options.fit The technique used to fit the image into the display, in case the image and the display have different aspect ratios. This can be ``fit`` (default), ``zoom``, or ``stretch``.
@@ -396,7 +396,7 @@ if (PHONE_IOT_MODE === 'native' || PHONE_IOT_MODE === 'both') {
      * @param {Size} height Height of the text field (percentage).
      * @param {Object=} options Additional options
      * @param {String=} options.id The id to use for the control. If not specified, a new one will be automatically generated.
-     * @param {String=} options.event The name of an event to send every time the user changes the text content (only possible if ``readonly = false``). Note that this event is only sent once the user clicks accept on the new content (you do not get an event for every key press). You must call :func:`PhoneIoT.listenToGUI` to actually receive these messages. If not specified, no event is sent. Message fields: ``id``, ``text``.
+     * @param {String=} options.event The name of an event to send every time the user changes the text content (only possible if ``readonly = false``). Note that this event is only sent once the user clicks accept on the new content (you do not get an event for every key press). You must call :func:`PhoneIoT.listenToGUI` to actually receive these messages. If not specified, no event is sent. Message fields: ``device``, ``id``, ``text``.
      * @param {String=} options.text This can be used to set the initial text of the text field once created. Defaults to empty if not specified.
      * @param {Color=} options.color The color of the text field border.
      * @param {Color=} options.textColor The text color of the text field.
@@ -433,7 +433,7 @@ if (PHONE_IOT_MODE === 'native' || PHONE_IOT_MODE === 'both') {
      * @param {Size} width Width of the joystick (percentage).
      * @param {Object=} options Additional options
      * @param {String=} options.id The id to use for the control. If not specified, a new one will be automatically generated.
-     * @param {String=} options.event The name of a message type to be sent each time the user moves the joystick. The messages also include a ``tag`` field which functions identically to the one in :func:`PhoneIoT.addTouchpad`. You must call :func:`PhoneIoT.listenToGUI` to actually receive these messages. If not specified, no event is sent. Message fields: ``id``, ``x``, ``y``, ``tag``.
+     * @param {String=} options.event The name of a message type to be sent each time the user moves the joystick. The messages also include a ``tag`` field which functions identically to the one in :func:`PhoneIoT.addTouchpad`. You must call :func:`PhoneIoT.listenToGUI` to actually receive these messages. If not specified, no event is sent. Message fields: ``device``, ``id``, ``x``, ``y``, ``tag``.
      * @param {Color=} options.color The color of the joystick.
      * @param {Boolean=} options.landscape If set to ``true``, the ``x`` and ``y`` values of the joystick are altered so that it acts correctly when in landscape mode. Unlike other controls, this option does not affect where the control is displayed on the screen (no rotation).
      * @returns {String} id of the created control
@@ -464,7 +464,7 @@ if (PHONE_IOT_MODE === 'native' || PHONE_IOT_MODE === 'both') {
      * @param {Size} height Height of the touchpad (percentage).
      * @param {Object=} options Additional options
      * @param {String=} options.id The id to use for the control. If not specified, a new one will be automatically generated.
-     * @param {String=} options.event The name of a message type to be sent each time the user touches, slides, or lets go of the touchpad. A message field called ``tag`` is included to differentiate the different types of interactions; it is one of ``down`` (touch started), ``up`` (touch ended), or ``move`` (during continued/held touch). You must call :func:`PhoneIoT.listenToGUI` to actually receive these messages. If not specified, no event is sent. Message fields: ``id``, ``x``, ``y``, ``tag``.
+     * @param {String=} options.event The name of a message type to be sent each time the user touches, slides, or lets go of the touchpad. A message field called ``tag`` is included to differentiate the different types of interactions; it is one of ``down`` (touch started), ``up`` (touch ended), or ``move`` (during continued/held touch). You must call :func:`PhoneIoT.listenToGUI` to actually receive these messages. If not specified, no event is sent. Message fields: ``device``, ``id``, ``x``, ``y``, ``tag``.
      * @param {Color=} options.color The color of the touchpad.
      * @param {TouchpadStyle=} options.style Controls the appearance of the touchpad. These are the same as for :func:`PhoneIoT.addButton` except that only ``rectangle`` and ``square`` are allowed.
      * @param {Boolean=} options.landscape ``true`` to rotate the control ``90`` degrees into landscape mode.
@@ -494,7 +494,7 @@ if (PHONE_IOT_MODE === 'native' || PHONE_IOT_MODE === 'both') {
      * @param {Size} width Width (length) of the slider (percentage).
      * @param {Object=} options Additional options
      * @param {String=} options.id The id to use for the control. If not specified, a new one will be automatically generated.
-     * @param {String=} options.event The name of a message type to be sent each time the user touches, slides, or lets go of the slider. The messages also include a ``tag`` field which functions identically to the one in :func:`PhoneIoT.addTouchpad`. You must call :func:`PhoneIoT.listenToGUI` to actually receive these messages. If not specified, no event is sent. Message fields: ``id``, ``level``, ``tag``.
+     * @param {String=} options.event The name of a message type to be sent each time the user touches, slides, or lets go of the slider. The messages also include a ``tag`` field which functions identically to the one in :func:`PhoneIoT.addTouchpad`. You must call :func:`PhoneIoT.listenToGUI` to actually receive these messages. If not specified, no event is sent. Message fields: ``device``, ``id``, ``level``, ``tag``.
      * @param {Color=} options.color The color of the slider.
      * @param {BoundedNumber<0,1>=} options.value The initial value of the slider (default ``0.0``).
      * @param {SliderStyle=} options.style Controls the appearance of the slider. Allowed values are ``slider`` (default) or ``progress``.
@@ -526,7 +526,7 @@ if (PHONE_IOT_MODE === 'native' || PHONE_IOT_MODE === 'both') {
      * @param {Object=} options Additional options
      * @param {ToggleStyle=} options.style The visual style of the toggle control. This can be ``switch`` (default) for a mobile-style toggle, or ``checkbox`` for a desktop-style toggle.
      * @param {String=} options.id The id to use for the control. If not specified, a new one will be automatically generated.
-     * @param {String=} options.event The name of a message to be sent every time the checkbox is toggled by the user. You must call :func:`PhoneIoT.listenToGUI` to actually receive these messages. Message fields: ``id``, ``state``.
+     * @param {String=} options.event The name of a message to be sent every time the checkbox is toggled by the user. You must call :func:`PhoneIoT.listenToGUI` to actually receive these messages. Message fields: ``device``, ``id``, ``state``.
      * @param {Boolean=} options.checked Defaults to ``false``. If set to ``true``, the toggle will be initially checked.
      * @param {Color=} options.color The color of the toggle itself.
      * @param {Color=} options.textColor The text color of the toggle.
@@ -563,7 +563,7 @@ if (PHONE_IOT_MODE === 'native' || PHONE_IOT_MODE === 'both') {
      * @param {Object=} options Additional options
      * @param {String=} options.group The name of the group to associate this radio button with. You do not need this value to access the control later. If not specified, defaults to ``main``.
      * @param {String=} options.id The id to use for the control. If not specified, a new one will be automatically generated.
-     * @param {String=} options.event The name of an event to send every time the user clicks the radio button. Note that clicking a radio button always checks it, unlike toggles. You must call :func:`PhoneIoT.listenToGUI` to actually receive these messages. If not specified, no event is sent. Message fields: ``id``, ``state``.
+     * @param {String=} options.event The name of an event to send every time the user clicks the radio button. Note that clicking a radio button always checks it, unlike toggles. You must call :func:`PhoneIoT.listenToGUI` to actually receive these messages. If not specified, no event is sent. Message fields: ``device``, ``id``, ``state``.
      * @param {Boolean=} options.checked Defaults to ``false``. If set to ``true``, the radio button will be initially checked. Note that, while the user cannot check multiple radio buttons, you are free to do so programmatically.
      * @param {Color=} options.color The color of the radio button itself.
      * @param {Color=} options.textColor The text color of the radio button.
@@ -852,7 +852,8 @@ if (PHONE_IOT_MODE === 'native' || PHONE_IOT_MODE === 'both') {
         return this._passToDevice('getOrientation', arguments);
     };
     /**
-     * Gets the current compass heading from the device. This is similar to :func:`PhoneIoT.getBearing`, except that it returns the angle from magnetic north, rather than the direction of travel.
+     * Gets the current compass heading from the device.
+     * This is similar to :func:`PhoneIoT.getGPSHeading`, except that it returns the angle from magnetic north, rather than the direction of travel.
      * This is provided by the magnetic field sensor, so using this RPC on devices without a magnetometer will result in an error.
      * The output of this RPC assumes the device is face-up.
      * 
@@ -1069,7 +1070,7 @@ if (PHONE_IOT_MODE === 'native' || PHONE_IOT_MODE === 'both') {
      * 
      * Sensor name: ``location``
      * 
-     * Message fields: ``latitude``, ``longitude``, ``bearing``, ``altitude``, ``device``
+     * Message fields: ``latitude``, ``longitude``, ``heading``, ``altitude``, ``device``
      * 
      * @category Sensors
      * @param {Device} device id of the device
@@ -1079,29 +1080,40 @@ if (PHONE_IOT_MODE === 'native' || PHONE_IOT_MODE === 'both') {
         return this._passToDevice('getLocation', arguments);
     };
     /**
-     * Returns the current bearing (direction of travel) from the device.
+     * Returns the current heading (direction of travel) from the device.
      * This is provided by the location sensor, so you must have location turned on and give the app permission.
-     * The bearing is expressed as the angle (in degrees) from North, going clockwise.
+     * The heading is expressed as the angle (in degrees) from North, going clockwise.
      * Thus, you can directly use this value in a ``point in direction`` block to point a sprite in the direction of travel (assuming North is up).
+     * 
+     * Note that headings based on location work by approximating your direction of travel, rather than which way you are facing.
+     * Thus, this will not work while standing still.
+     * In these cases, consider using :func:`PhoneIoT.getCompassHeading` instead.
      * 
      * Sensor name: ``location``
      * 
-     * Message fields: ``latitude``, ``longitude``, ``bearing``, ``altitude``, ``device``
+     * Message fields: ``latitude``, ``longitude``, ``heading``, ``altitude``, ``device``
      * 
      * @category Sensors
      * @param {Device} device id of the device
-     * @returns {Number} current bearing (in degrees)
+     * @returns {Number} current heading (in degrees)
      */
-    PhoneIoT.prototype.getBearing = function (device) {
-        return this._passToDevice('getBearing', arguments);
+    PhoneIoT.prototype.getGPSHeading = function (device) {
+        return this._passToDevice('getGPSHeading', arguments);
     };
+    /**
+     * @deprecated
+     * @category Sensors
+     * @param {Device} device id of the device
+     * @returns {Number} current heading (in degrees)
+    */
+    PhoneIoT.prototype.getBearing = this.getGPSHeading;
     /**
      * Returns the current altitude of the device, expressed in meters above sea level.
      * This is provided by the location service on the device, so you must have location turned on and give the app permission.
      * 
      * Sensor name: ``location``
      * 
-     * Message fields: ``latitude``, ``longitude``, ``bearing``, ``altitude``, ``device``
+     * Message fields: ``latitude``, ``longitude``, ``heading``, ``altitude``, ``device``
      * 
      * @category Sensors
      * @param {Device} device id of the device

--- a/test/unit/server/services/procedures/phone-iot.spec.js
+++ b/test/unit/server/services/procedures/phone-iot.spec.js
@@ -41,6 +41,7 @@ describe(utils.suiteName(__filename), function() {
         ['getLocation', ['device']],
         ['getProximity', ['device']],
         ['getBearing', ['device']],
+        ['getGPSHeading', ['device']],
         ['getAltitude', ['device']],
         ['getStepCount', ['device']],
         ['getLightLevel', ['device']],


### PR DESCRIPTION
Updates PhoneIoT messages from widgets to also send the device ID, which is useful if one project connects to multiple devices (alternative was making unique ids for the same control on different devices, such as name mangling).

Also renames `bearing` values to `heading` (I had the terminology wrong originally), as well as `getBearing` to `getGPSHeading`. These changes are backwards compatible since both `heading` and `bearing` (deprecated) are sent in sensor updates, and `getBearing` is now a deprecated alias to `getGPSHeading`.