### PR TITLE
CloudVariables Fused Ops

### DIFF
--- a/src/server/services/procedures/cloud-variables/cloud-variables.js
+++ b/src/server/services/procedures/cloud-variables/cloud-variables.js
@@ -466,4 +466,48 @@ CloudVariables.listenToUserVariable = async function(name, msgType, duration = 6
     bucket[this.socket.clientId] = [this.socket, msgType, +new Date() + duration];
 };
 
+/**
+ * Equivalent to calling :func:`CloudVariables.lockVariable` followed by :func:`CloudVariables.getVariable`.
+ * @param {String} name Variable name
+ * @param {String=} password Password (if password-protected)
+ */
+ CloudVariables.lockAndGetVariable = async function(name, password) {
+    await this.lockVariable(name, password);
+    return await this.getVariable(name, password);
+};
+
+/**
+ * Equivalent to calling :func:`CloudVariables.setVariable` followed by :func:`CloudVariables.unlockVariable`.
+ * @param {String} name Variable name
+ * @param {Any} value Value to store in variable
+ * @param {String=} password Password (if password-protected)
+ */
+CloudVariables.setAndUnlockVariable = async function(name, value, password) {
+    await this.setVariable(name, value, password);
+    await this.unlockVariable(name, password);
+};
+
+/**
+ * Sets the variable to the given value and returns the previous value.
+ * @param {String} name Variable name
+ * @param {Any} value Value to store in variable
+ * @param {String=} password Password (if password-protected)
+ */
+CloudVariables.getAndSetVariable = async function(name, value, password) {
+    const res = await this.getVariable(name, password);
+    await this.setVariable(name, value, password);
+    return res;
+};
+
+/**
+ * Sets the variable to the given value and returns the previous value.
+ * @param {String} name Variable name
+ * @param {Any} value Value to store in variable
+ */
+CloudVariables.getAndSetUserVariable = async function(name, value) {
+    const res = await this.getUserVariable(name);
+    await this.setUserVariable(name, value);
+    return res;
+};
+
 module.exports = CloudVariables;

--- a/test/unit/server/services/procedures/cloud-variables.spec.js
+++ b/test/unit/server/services/procedures/cloud-variables.spec.js
@@ -23,6 +23,10 @@ describe(utils.suiteName(__filename), function() {
         ['deleteUserVariable', ['name']],
         ['listenToVariable', ['name', 'msgType', 'password', 'duration']],
         ['listenToUserVariable', ['name', 'msgType', 'duration']],
+        ['lockAndGetVariable', ['name', 'password']],
+        ['setAndUnlockVariable', ['name', 'value', 'password']],
+        ['getAndSetVariable', ['name', 'value', 'password']],
+        ['getAndSetUserVariable', ['name', 'value']],
     ]);
 
     let counter = 0;


### PR DESCRIPTION
These are the fused ops that were removed from #3369.

@brollb I'm curious about your RAII idea. I actually wanted to do something like that initially, but I didn't know if we had machinery for that kind of logic. I considered deprecating lock/unlock and replacing them with `lockAnd` which takes (the var name/pass and) a serialized function to perform under lock. This means users can't forget to unlock, but ringified blocks can scare people off (and this wouldn't work from PyBlox).