### PR TITLE
Forbid NetsBlox HTTP Reqs

### DIFF
--- a/src/server/server.js
+++ b/src/server/server.js
@@ -414,7 +414,7 @@ Server.prototype.createRouter = function() {
             }
 
             router.route(api.URL)[method](async (req, res) => {
-                const isFromNetsBlox = 'x-netsblox-source' in req.headers;
+                const isFromNetsBlox = req.headers['x-source'] === 'NetsBlox';
                 if (isFromNetsBlox) {
                     logger.warn(`blocked NetsBlox-origin request to ${api.URL}`);
                     return res.status(403).send('ERROR: Operation is not allowed');

--- a/src/server/server.js
+++ b/src/server/server.js
@@ -414,6 +414,12 @@ Server.prototype.createRouter = function() {
             }
 
             router.route(api.URL)[method](async (req, res) => {
+                const isFromNetsBlox = 'x-netsblox-source' in req.headers;
+                if (isFromNetsBlox) {
+                    logger.warn(`blocked NetsBlox-origin request to ${api.URL}`);
+                    return res.status(403).send('ERROR: Operation is not allowed');
+                }
+
                 if (api.Service) {
                     const args = (api.Parameters || '').split(',')
                         .map(name => {


### PR DESCRIPTION
@brollb Adds a global 403 filter to all routes that forbids any request with an `x-netsblox-source` header. This requires the corresponding [browser PR](https://github.com/NetsBlox/Snap--Build-Your-Own-Blocks/pull/1297) to actually block anything.