### PR TITLE
Better Link Markup Cleaning

### DIFF
--- a/src/server/services/jsdoc-extractor.js
+++ b/src/server/services/jsdoc-extractor.js
@@ -14,18 +14,18 @@ let parseSync = (filePath, searchScope = 5) => {
     return parseSource(source, searchScope);
 };
 
-const RTD_ROLE_REGEX = /:(\w+:)?\w+:`([^`]+)`/g;
-const RTD_BOLD_REGEX = /\*\*([^*]+)\*\*/g;
-const RTD_CODE_REGEX = /``([^`]+)``/g;
-const RTD_LINK_REGEX = /`([^`]+)`_/g;
-const RTD_EMPH_REGEX = /`([^`]+)`/g;
+const MARKUP_REPLACE_GROUPS = [
+    [/:(\w+:)?\w+:`([^`]+)`/g, '$2'], // role (used for service/rpc references)
+    [/`([^`]+?)\s*<([^`]+)>`__?/g, '$1 ($2)'], // link
+    [/\*\*([^*]+)\*\*/g, '$1'], // bold
+    [/``([^`]+)``/g, '$1'], // code
+    [/`([^`]+)`/g, '$1'], // italics
+];
 function cleanMarkup(str) {
     if (!str) return str;
-    str = str.replace(RTD_ROLE_REGEX, '$2');
-    str = str.replace(RTD_BOLD_REGEX, '$1');
-    str = str.replace(RTD_CODE_REGEX, '$1');
-    str = str.replace(RTD_LINK_REGEX, '$1');
-    str = str.replace(RTD_EMPH_REGEX, '$1');
+    for (const [regex, replace] of MARKUP_REPLACE_GROUPS) {
+        str = str.replace(regex, replace)
+    }
     return str;
 }
 

--- a/src/server/services/jsdoc-extractor.js
+++ b/src/server/services/jsdoc-extractor.js
@@ -24,7 +24,7 @@ const MARKUP_REPLACE_GROUPS = [
 function cleanMarkup(str) {
     if (!str) return str;
     for (const [regex, replace] of MARKUP_REPLACE_GROUPS) {
-        str = str.replace(regex, replace)
+        str = str.replace(regex, replace);
     }
     return str;
 }

--- a/src/server/services/procedures/shared-canvas/shared-canvas.js
+++ b/src/server/services/procedures/shared-canvas/shared-canvas.js
@@ -3,7 +3,7 @@
  * Users can view the canvas, or edit it pixel by pixel.
  * However, there is a cooldown between canvas edits, meaning one user cannot dominate the entire canvas.
  *
- * SharedCanvas was inspired by `Place <https://en.wikipedia.org/wiki/Place_(Reddit)>`__, which was
+ * SharedCanvas was inspired by `Place <https://en.wikipedia.org/wiki/R/place>`__, which was
  * a social experiment started on Reddit that functioned in much the same way. Place came to capture
  * Reddit's online culture through the combined efforts of many users striving to control the canvas
  * and display their own images.


### PR DESCRIPTION
Improves RST link markup cleaning. Links in RST take the form `` `label <target>`_ ``, or `` `label <target>`__ `` for anonymous links (preferred). The old cleanup logic was just taking the interior like `label <target>`, and only 1 underscore. The new cleanup logic takes both underscores and cleans it to `label (target)`.