### PR TITLE
fix Date parsing edge case

### DIFF
--- a/src/server/services/input-types.js
+++ b/src/server/services/input-types.js
@@ -461,7 +461,7 @@ function parseDuration(input) {
     let res = 0;
     while (input.length != 0) {
         const delta = input.match(/^([+-]?)\s*(\d+\.?\d*)\s*([^+-\s]*)/);
-        if (!delta) throw Error(`Failed to parse ${input} as a duration`);
+        if (!delta) throw Error(`Failed to parse "${input}" as a duration`);
         if (delta[3].length === 0) throw Error(`Time offset "${delta[0]}" missing units`);
 
         input = input.slice(delta[0].length).trimLeft();
@@ -500,6 +500,14 @@ defineType({
 
         const MAX_DATE_LEN = 128;
         let dateLen = Math.min(MAX_DATE_LEN, input.length);
+        let deltaSepPos = 0;
+        let spacePrefix = true;
+        for (; deltaSepPos < dateLen; ++deltaSepPos) {
+            if (!spacePrefix && '+-'.includes(input[deltaSepPos]) && ' \t'.includes(input[deltaSepPos - 1])) break;
+            if (spacePrefix && !' \t'.includes(input[deltaSepPos])) spacePrefix = false;
+        }
+        dateLen = deltaSepPos;
+
         let date = null;
         for (; dateLen > 0; --dateLen) {
             date = basicParser(input.slice(0, dateLen), null);

--- a/test/unit/server/services/input-types.spec.js
+++ b/test/unit/server/services/input-types.spec.js
@@ -205,6 +205,18 @@ describe(utils.suiteName(__filename), function() {
             assertDatesEq(await parse('  2353436446  '), new Date(2353436446));
         });
 
+        it('should stop on +/- for base date parsing', async () => {
+            assertDatesEq(await parse('now -1d'), +new Date() - 1*24*60*60*1000);
+            assertDatesEq(await parse('now -3d'), +new Date() - 3*24*60*60*1000);
+            assertDatesEq(await parse('now -10d'), +new Date() - 10*24*60*60*1000);
+            assertDatesEq(await parse('now -30d'), +new Date() - 30*24*60*60*1000);
+
+            assertDatesEq(await parse('now +1d'), +new Date() + 1*24*60*60*1000);
+            assertDatesEq(await parse('now +3d'), +new Date() + 3*24*60*60*1000);
+            assertDatesEq(await parse('now +10d'), +new Date() + 10*24*60*60*1000);
+            assertDatesEq(await parse('now +30d'), +new Date() + 30*24*60*60*1000);
+        });
+
         it('should allow slightly extended unix timestamps', async () => {
             assertDatesEq(await parse('+2353436446'), new Date(2353436446));
             assertDatesEq(await parse('  +2353436446  '), new Date(2353436446));


### PR DESCRIPTION
Fixes an edge case of parsing `Date` objects that was causing `today +1d` (today plus 1 day) to fail to parse because javascript accepts `today +1` as a valid builtin `Date` with Unix epoch timestamp `1`, and the rest of the string then fails to parse as an offset sequence.