### PR TITLE
change Thingspeak to use meters

### DIFF
--- a/src/server/services/procedures/thing-speak/thing-speak.js
+++ b/src/server/services/procedures/thing-speak/thing-speak.js
@@ -118,12 +118,13 @@ thingspeakIoT.searchByTag = function(tag, limit=15, updatedSince=null) {
  *
  * @param {Latitude} latitude latitude to search near
  * @param {Longitude} longitude longitude to search near
- * @param {BoundedNumber<0>=} distance max distance from location (default ``100``)
+ * @param {BoundedNumber<0>=} distance max distance from location in meters (default ``100000`` = 100Km)
  * @param {Number=} limit max number of results to return (default ``15``)
  * @param {Date=} updatedSince only include results which have (some) new data since this date (default no time-based filtering)
  * @returns {Array<Object>} search results
  */
-thingspeakIoT.searchByLocation = function(latitude, longitude, distance=100, limit=15, updatedSince=null) {
+thingspeakIoT.searchByLocation = function(latitude, longitude, distance=100000, limit=15, updatedSince=null) {
+    distance /= 1000; // convert to Km for Thingspeak API
     const pred = getUpdatedSincePred(updatedSince);
     return this._paginatedSearch('public.json', { latitude, longitude, distance }, limit, pred).catch(this._handleError);
 };
@@ -134,12 +135,13 @@ thingspeakIoT.searchByLocation = function(latitude, longitude, distance=100, lim
  * @param {String} tag tag to search for
  * @param {Latitude} latitude latitude to search near
  * @param {Longitude} longitude longitude to search near
- * @param {BoundedNumber<0>=} distance max distance from location (default ``100``)
+ * @param {BoundedNumber<0>=} distance max distance from location in meters (default ``100000`` = 100Km)
  * @param {Number=} limit max number of results to return (default ``15``)
  * @param {Date=} updatedSince only include results which have (some) new data since this date (default no time-based filtering)
  * @returns {Array<Object>} search results
  */
-thingspeakIoT.searchByTagAndLocation = function(tag, latitude, longitude, distance=100, limit=15, updatedSince=null) {
+thingspeakIoT.searchByTagAndLocation = function(tag, latitude, longitude, distance=100000, limit=15, updatedSince=null) {
+    distance /= 1000; // convert to Km for Thingspeak API
     const updatedSincePred = getUpdatedSincePred(updatedSince);
     const pred = v => {
         if ((v.tags || []).every(t => !(t.name || '').includes(tag))) {


### PR DESCRIPTION
Changes Thingspeak RPCs to use meters for distance-based filtering. Previously the units were undocumented (both in NetsBlox and the Thingspeak API), but experimentation shows that it was actually expecting meters. This changes the RPCs to expect meters instead, which matches other services like GoogleMaps and Geolocation.