### PR TITLE
Default username should be from cookie - not request body

### DIFF
--- a/src/server/routes/middleware.js
+++ b/src/server/routes/middleware.js
@@ -110,7 +110,7 @@ async function login(req, res) {
 
     await Q.nfcall(tryLogIn, req, res);
     loggedIn = req.loggedIn;
-    username = username || req.session.username;
+    username = req.session.username || username;
 
     if (!username) {
         logger.log('"passive" login failed - no session found!');


### PR DESCRIPTION
Originally, this was written with the username, password in the body but then updated to allow logging in from the cookie (no credentials in the body). This meant that the username may be undefined when retrieved from the request body. If this was the case, I had updated the method to grab it from the cookie.

However, this exposes a pretty big security vulnerability if someone logs in with 1 account and sends a different username in the request body. The cookie will authenticate the user but then `username` will resolve to the incorrect value. (It should resolve to the value from the cookie rather than request body.)