### PR TITLE
Autograders Fix

### DIFF
--- a/src/server/services/procedures/autograders/template.ejs
+++ b/src/server/services/procedures/autograders/template.ejs
@@ -497,7 +497,12 @@
             let index = 0;
             const testCaseName = BlockMorph.prototype.parseSpec(spec)
                 .map(spec => {
-                    const isInput = !BlockMorph.prototype.labelPart(spec);
+                    let isInput = true;
+                    try {
+                        BlockMorph.prototype.labelPart(spec);
+                        isInput = false;
+                    } catch {}
+
                     if (isInput) {
                         return JSON.stringify(inputs[index++]);
                     }


### PR DESCRIPTION
Handle exceptions from the new `labelPart` code (used to return `null`).