### PR TITLE
Wildcam

### DIFF
--- a/src/server/services/procedures/wildcam/downloader.py
+++ b/src/server/services/procedures/wildcam/downloader.py
@@ -1,0 +1,51 @@
+import os
+import sys
+import json
+import threading
+import urllib.request
+
+if __name__ == '__main__':
+    if len(sys.argv) != 4:
+        print(f'usage: {sys.argv[0]} <CSV PATH> <SAVE DIR> <THREADS>')
+        sys.exit(1)
+
+    with open(sys.argv[1], 'r') as f:
+        content = f.read()
+
+    save_dir = sys.argv[2]
+    os.mkdir(save_dir)
+
+    thread_count = int(sys.argv[3])
+
+    urls = set()
+    for line in content.splitlines()[1:]:
+        vals = [val[1:-1] if val[0] == val[-1] and val[0] == '"' else val for val in line.split(',')]
+        if len(vals) == 0 or (len(vals) == 1 and vals[0] == ''): continue
+        assert vals[-1].startswith('http'), vals
+        urls.add(vals[-1])
+    urls = { v: f'{i:05}.jpg' for i, v in enumerate(urls) }
+
+    it = iter(urls.items())
+    lock = threading.Lock()
+
+    def thread_fn():
+        while True:
+            with lock:
+                try:
+                    url, file_name = next(it)
+                except StopIteration:
+                    return
+            print(f'downloading {file_name}')
+            with urllib.request.urlopen(url) as src:
+                with open(f'{save_dir}/{file_name}', 'wb') as dst:
+                    dst.write(src.read())
+
+    threads = [threading.Thread(target = thread_fn) for _ in range(thread_count)]
+    for thread in threads:
+        thread.start()
+    for thread in threads:
+        thread.join()
+
+    print('saving index')
+    with open(f'{save_dir}/index.json', 'w') as f:
+        json.dump(urls, f)

--- a/src/server/services/procedures/wildcam/readme.md
+++ b/src/server/services/procedures/wildcam/readme.md
@@ -1,0 +1,7 @@
+## Image Backups
+
+As a backup plan in case the data source were to ever be taken offline, the [`downloader.py`](downloader.py) script
+was written to quickly download all the images (with metadata already being saved in the CSV file itself).
+This was run once and stored in google drive long-term, but the script remains in case the image source is ever updated.
+At the time of writing, the total image dataset is around 3.3GB.
+Obviously, don't commit the downloaded image files to the repository...

--- a/src/server/services/procedures/wildcam/wildcam.js
+++ b/src/server/services/procedures/wildcam/wildcam.js
@@ -1,0 +1,139 @@
+/**
+ * Wildcam provides access to wildlife images from around the world.
+ * 
+ * Current data sources:
+ * 
+ * - `Zooniverse <https://classroom.zooniverse.org/#/wildcam-gorongosa-lab/explorers/map/>`__
+ * 
+ * @service
+ * @category GeoData
+ * @category Media
+ */
+'use strict';
+
+const fs = require('fs');
+const path = require('path');
+const axios = require('axios');
+const logger = require('../utils/logger')('wildcam');
+
+// -------------------------------------------------------------------------
+
+const CSV_PATH = path.join(__dirname, 'wildcam-17nov2022.csv');
+
+// -------------------------------------------------------------------------
+
+const IMG_CACHE = {};
+
+const Wildcam = {};
+
+function strictParseFloat(val) {
+    const res = parseFloat(val);
+    if (isNaN(res)) throw Error(`failed to parse '${val}' as a float`);
+    return res;
+}
+function strictParseInt(val) {
+    const res = parseInt(val);
+    if (isNaN(res)) throw Error(`failed to parse '${val}' as a int`);
+    return res;
+}
+function strictParseDate(val) {
+    let match = val.match(/^(\d{4})-([01]?\d)-([0-3]?\d)$/);
+    if (match) return new Date(parseInt(match[1]), parseInt(match[2]) - 1, parseInt(match[3]));
+
+    match = val.match(/^([01]?\d)\/([0-3]?\d)\/(\d{4})$/);
+    if (match) return new Date(parseInt(match[3]), parseInt(match[1]) - 1, parseInt(match[2]));
+
+    throw Error(`unknown date format '${val}'`);
+}
+
+const DATA = (function() {
+    const csvLines = fs.readFileSync(CSV_PATH, 'utf8').split(/\r?\n/);
+    const res = {};
+
+    for (let i = 1; i < csvLines.length; ++i) {
+        try {
+            const items = csvLines[i]
+                .split(',')
+                .map(x => x.trim())
+                .map(x => x.length && x[0] === x[x.length - 1] && x[0] === '"' ? x.substring(1, x.length - 1) : x);
+
+            if (items.length === 0 || (items.length === 1 && items[0] === '')) continue;
+            if (items.length !== 24) throw Error(`wrong col count - expected 24 got ${items.length}`);
+
+            let entry = res[items[23]];
+            if (!entry) entry = res[items[23]] = {
+                date: strictParseDate(items[4]),
+                timePeriod: items[8].split(' ')[0].toLowerCase(),
+                latitude: strictParseFloat(items[3]),
+                longitude: strictParseFloat(items[2]),
+                vegetationType: items[9].toLowerCase(),
+                waterType: items[12].toLowerCase(),
+                waterDistance: strictParseFloat(items[13]),
+                structureType: items[10].toLowerCase(),
+                structureDistance: strictParseFloat(items[11]),
+                species: [],
+                imageUrl: items[23],
+            }
+
+            entry.species.push({
+                name: items[14].toLowerCase(),
+                adults: strictParseInt(items[15]),
+                young: strictParseInt(items[21] || '0'),
+            });
+        } catch (ex) {
+            throw new Error(`line ${i+1}: ${ex}`);
+        }
+    }
+
+    const sorted = Object.values(res);
+    sorted.sort((a, b) => +a.date - +b.date);
+
+    return sorted;
+})();
+
+/**
+ * Searches the database for wildlife camera entries.
+ * Each return value includes information about the contents of its associated image.
+ * You can pass an entry to :func:`Wildcam.getImage` to get the actual image being described.
+ * 
+ * @param {Date=} startDate The earliest date to include in the results. If omitted, no starting cutoff is used for filtering.
+ * @param {Date=} stopDate The latest date to include in the results. If omitted, no stopping cutoff is used for filtering.
+ * @returns {Array<Object>} all data entries matching the search, in chronological order
+ */
+Wildcam.search = function (startDate = null, stopDate = null) {
+    startDate = startDate ? +startDate : -Infinity;
+    stopDate = stopDate ? +stopDate : Infinity;
+
+    return DATA.filter(x => {
+        const time = +x.date;
+        if (time < startDate || time > stopDate) return false;
+        return true;
+    });
+};
+
+/**
+ * Gets the image associated with a given entry.
+ * The provided entry should be exactly the format that was returned by one of the various search RPCs in this service.
+ * 
+ * @param {Object} entry the search entry to get an image of
+ * @returns {Image} the snapshot associated with the given entry
+ */
+Wildcam.getImage = async function(entry) {
+    const url = entry.imageUrl;
+    logger.info(`requesting image from: ${url}`);
+
+    let data = IMG_CACHE[url];
+    if (!data) {
+        logger.info('image not cached - downloading...');
+        data = IMG_CACHE[url] = (await axios({ url, method: 'GET', responseType: 'arraybuffer' })).data;
+    }
+
+    this.response.set('content-type', 'image/jpeg');
+    this.response.set('content-length', data.length);
+    this.response.set('connection', 'close');
+
+    logger.info('sent the image');
+    return this.response.status(200).send(data);
+};
+
+module.exports = Wildcam;

--- a/test/unit/server/services/procedures/wildcam.spec.js
+++ b/test/unit/server/services/procedures/wildcam.spec.js
@@ -1,0 +1,8 @@
+const utils = require('../../../../assets/utils');
+
+describe(utils.suiteName(__filename), function() {
+    utils.verifyRPCInterfaces('Wildcam', [
+        ['search', ['startDate', 'stopDate']],
+        ['getImage', ['entry']],
+    ]);
+});

--- a/test/unit/server/services/procedures/wildcam.spec.js
+++ b/test/unit/server/services/procedures/wildcam.spec.js
@@ -2,7 +2,8 @@ const utils = require('../../../../assets/utils');
 
 describe(utils.suiteName(__filename), function() {
     utils.verifyRPCInterfaces('Wildcam', [
-        ['search', ['startDate', 'stopDate']],
+        ['search', ['startDate', 'stopDate', 'species', 'latitude', 'longitude', 'radius']],
         ['getImage', ['entry']],
+        ['getSpeciesList', []],
     ]);
 });


### PR DESCRIPTION
Add `Wildcam` service for getting wildlife images from camera traps. Currently the `search` RPC just has date filtering, but there are lots of fields we could filter on. Probably the next good one would be location based like min/max lat/long for filling a google maps image with points, or possibly lat/long center an max distance in Km. Holding off to discuss filtering options.