### PR TITLE
Revert uncommented lines in docker-compose

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -20,13 +20,12 @@ services:
     environment:
         - "NETSBLOX_CLOUD=http://cloud:7777"
         - "NETSBLOX_CLOUD_ID=NetsBloxServices"
-        - "NETSBLOX_CLOUD_SECRET=f13d0e98-b3f9-433b-aca6-19090e5ee849"  # TODO: Put the output from "netsblox service-hosts authorize" here
+        - "NETSBLOX_CLOUD_SECRET=PUT_SECRET_HERE"  # TODO: Put the output from "netsblox service-hosts authorize" here
         - "PORT=8081"
         - "MONGO_URI=mongodb://mongo:27017"
-        - "THE_CAT_API_KEY=live_yL38pOVfFAQFLVu0Pk9bu1R26Msm8cZc6nmckkeymTJ9F3zpjBrCZtVhiM3WD4Pm"
 # Uncomment the following 2 lines to use the local services code in the container (for development)
-    volumes:
-       - "${PWD}/services/src:/netsblox/src"
+#    volumes:
+#        - "${PWD}/services/src:/netsblox/src"
     depends_on:
         - cloud
 
@@ -39,8 +38,8 @@ services:
         - "CLOUD_URL=http://127.0.0.1:7777"
         - "PORT=8080"
 # Uncomment the following 2 lines to use the local browser code in the container (for development)
-    volumes:
-       - "${PWD}/browser/src:/netsblox/src"
+#    volumes:
+#        - "${PWD}/browser/src:/netsblox/src"
     depends_on:
         - cloud
 


### PR DESCRIPTION
Saw these were uncommented in fcfaf12a14d66091369aae6c050f130de29873ac, this re-comments the dev lines, along with removing an API key that should not be there.